### PR TITLE
コーダー初級#3 の教材ページを追加

### DIFF
--- a/docs/training/cbc_internal/beginner_3.html
+++ b/docs/training/cbc_internal/beginner_3.html
@@ -1,0 +1,916 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>コーダー初級#3</title>
+  <link rel="stylesheet" href="../css/training.css" />
+
+  <!-- ▼ このページ専用のスタイル -->
+  <link rel="stylesheet" href="../css/beginner_3.css" />
+
+  <!-- ▼ 開いたときに、ページの先頭から読み始められるようにする。
+       ブラウザが前回の位置へ戻すより先に動かす必要があるため、
+       training.js とは分けて <head> で読み込んでいる -->
+  <script src="../js/scroll-reset.js"></script>
+</head>
+<body>
+
+<!-- ============================================================
+     ヘッダー
+     ============================================================ -->
+<header>
+  <div class="header-inner">
+    <h1>コーダー初級#3</h1>
+  </div>
+</header>
+
+<main>
+
+  <!-- ============================================================
+       目次
+       ============================================================ -->
+  <section class="toc" id="top">
+    <h2>目次</h2>
+
+    <ol start="18">
+      <li><a href="#chapter18">枠の中に画像や色を入れる</a></li>
+      <li><a href="#chapter19">枠の中にテキストとリストを入れる</a></li>
+      <li><a href="#chapter20">シンプルなWebサイトの完成</a></li>
+    </ol>
+
+    <p class="lead" style="margin-top: 8px;">
+      このページでは、これまでに組み立てた「枠（ボックス）」の中にロゴ画像・背景色・背景画像・テキスト・リストを入れていきます。最終的に、1つの「SAMPLE SITE」として完成させます。
+    </p>
+  </section>
+
+
+  <!-- ============================================================
+       14. 枠の中に画像や色を入れる
+       ============================================================ -->
+  <section id="chapter18">
+    <h2>18. 枠の中に画像や色を入れる</h2>
+
+    <p>
+      前のページで用意した「枠（ボックス）」の中に、いよいよ中身を入れていきます。まずは画像と色です。画像の表示には大きく2つの方法があります。
+    </p>
+
+    <div class="grid-2">
+      <div class="card">
+        <h4>HTMLの <code>&lt;img&gt;</code> タグ</h4>
+        <p>画像そのものを1つの部品として枠の中に「置く」方法です。ロゴやアイコンなど、画像単体を表示したいときに使います。</p>
+      </div>
+      <div class="card">
+        <h4>CSSの <code>background</code> プロパティ</h4>
+        <p>枠の背景として画像を「敷く」方法です。画像の上に文字を重ねて表示したいときに向いています。</p>
+      </div>
+    </div>
+
+    <div class="caution">
+      <span class="label">はじめに：CSSを整理してから始める</span><br>
+      前のページで付けた<strong>枠線（<code>border</code>）・枠の大きさ（<code>width</code> / <code>height</code>）・枠どうしの間隔（<code>margin</code>）の指定は、枠の位置を目で確認するための一時的なもの</strong>でした。ここからは中に入れる画像やテキストに合わせて決めていくので、これらを削除します。ヘッダーの下線も、中身が入ると濃い線が目立つため淡いグレー（<code>#eee</code>）に変えます。<br>
+      整理すると <code>css/style.css</code> は次の状態になります。<strong>この内容に置き換えてから</strong>、先に進んでください。
+    </div>
+
+    <div class="vscode"><div class="vscode-titlebar"><span class="win-dot red"></span><span class="win-dot yellow"></span><span class="win-dot green"></span><span class="vscode-title">style.css — Visual Studio Code</span></div><div class="vscode-tabs"><div class="vscode-tab">index.html</div><div class="vscode-tab is-active">style.css</div></div><div class="vscode-body"><div class="vscode-gutter">1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+11
+12
+13
+14
+15
+16
+17
+18
+19
+20
+21
+22
+23
+24
+25
+26
+27
+28
+29</div><code class="vscode-code"><span class="sy-sel">*</span> {
+  <span class="sy-attr">box-sizing</span>: border-box;
+  <span class="sy-attr">margin</span>: <span class="sy-num">0</span>;
+  <span class="sy-attr">padding</span>: <span class="sy-num">0</span>;
+}
+
+<span class="sy-com">/* 中身は 980px に固定して中央寄せ（全幅の帯の中に置く） */</span>
+.header_contents,
+.contents,
+<span class="sy-sel">.footer_contents</span> {
+  <span class="sy-attr">width</span>: <span class="sy-num">980px</span>;
+  <span class="sy-attr">margin</span>: <span class="sy-num">0</span> auto;
+}
+
+<span class="sy-com">/* ヘッダー：全幅の帯（下線は淡いグレーにする） */</span>
+<span class="sy-sel">.header</span> {
+  <span class="sy-attr">border-bottom</span>: <span class="sy-num">1px</span> solid #eee;
+}
+
+<span class="sy-com">/* text と menu を横並びにする */</span>
+<span class="sy-sel">.text_wrapper</span> {
+  <span class="sy-attr">display</span>: flex;
+  <span class="sy-attr">justify-content</span>: center;
+}
+
+<span class="sy-com">/* フッター：全幅の暗い帯 */</span>
+<span class="sy-sel">.footer</span> {
+  <span class="sy-attr">background</span>: <span class="sy-num">#222</span>;
+}</code></div></div>
+
+    <p>
+      残っているのは、<strong>レイアウトの土台になる指定だけ</strong>です。
+    </p>
+
+    <h3>サイト全体の文字と色を決める</h3>
+    <p>
+      中身を入れる前に、ページ全体で使う<strong>書体・文字色・背景色</strong>を決めておきます。<code>body</code> に指定すると、その中のすべての文字に引き継がれます。
+    </p>
+
+    <div class="vscode"><div class="vscode-titlebar"><span class="win-dot red"></span><span class="win-dot yellow"></span><span class="win-dot green"></span><span class="vscode-title">style.css — Visual Studio Code</span></div><div class="vscode-tabs"><div class="vscode-tab">index.html</div><div class="vscode-tab is-active">style.css</div></div><div class="vscode-body"><div class="vscode-gutter">1
+2
+3
+4
+5
+6</div><code class="vscode-code"><span class="add"><span class="sy-com">/* サイト全体の文字と背景の基本を決める */</span></span><span class="add"><span class="sy-sel">body</span> {</span><span class="add">  <span class="sy-attr">font-family</span>: "Helvetica Neue", Arial, "Hiragino Sans", Meiryo, sans-serif;</span><span class="add">  <span class="sy-attr">color</span>: <span class="sy-num">#333</span>;</span><span class="add">  <span class="sy-attr">background</span>: #fff;</span><span class="add">}</span></code></div></div>
+
+
+    <div class="caution">
+      <span class="label">はじめに：素材をダウンロードして配置する</span><br>
+      この章で使うロゴ画像と背景画像は、下のボタンからダウンロードできます。ダウンロードして展開し、出てきた <code>images</code> フォルダを <code>index.html</code> と同じ場所に置きましょう。<br>
+      <a class="dl-btn" href="sample_site/images.zip" style="margin-top:10px;">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12"/><path d="m7 10 5 5 5-5"/><path d="M5 21h14"/></svg>images.zip をダウンロード
+      </a><span class="dl-note">ロゴ・背景画像などの素材一式</span>
+    </div>
+
+    <h3>ロゴ画像を <code>&lt;img&gt;</code> で置く</h3>
+    <p>
+      ヘッダーの <code>logo</code> という枠の中に、<code>&lt;img&gt;</code> タグで画像を、続けてサイト名の文字を入れます。<code>src</code> という属性は source（ソース＝元）の略で、表示する画像ファイルの場所を指定します。
+    </p>
+
+    <div class="vscode"><div class="vscode-titlebar"><span class="win-dot red"></span><span class="win-dot yellow"></span><span class="win-dot green"></span><span class="vscode-title">index.html — Visual Studio Code</span></div><div class="vscode-tabs"><div class="vscode-tab is-active">index.html</div><div class="vscode-tab">style.css</div></div><div class="vscode-body"><div class="vscode-gutter">1
+2
+3
+4
+5
+6
+7
+8</div><code class="vscode-code"><span class="add">&lt;<span class="sy-tag">div</span> <span class="sy-attr">class</span>=<span class="sy-str">"header"</span>&gt;</span><span class="add">  &lt;<span class="sy-tag">div</span> <span class="sy-attr">class</span>=<span class="sy-str">"header_contents"</span>&gt;</span><span class="add">    &lt;<span class="sy-tag">div</span> <span class="sy-attr">class</span>=<span class="sy-str">"logo"</span>&gt;</span><span class="add">      &lt;<span class="sy-tag">img</span> <span class="sy-attr">src</span>=<span class="sy-str">"images/logo_mark.webp"</span> <span class="sy-attr">alt</span>=<span class="sy-str">""</span> <span class="sy-attr">width</span>=<span class="sy-str">"40"</span> <span class="sy-attr">height</span>=<span class="sy-str">"40"</span>&gt;</span><span class="add">      SAMPLE SITE</span><span class="add">    &lt;/<span class="sy-tag">div</span>&gt;</span><span class="add">  &lt;/<span class="sy-tag">div</span>&gt;</span><span class="add">&lt;/<span class="sy-tag">div</span>&gt;</span></code></div></div>
+
+    <div class="vscode"><div class="vscode-titlebar"><span class="win-dot red"></span><span class="win-dot yellow"></span><span class="win-dot green"></span><span class="vscode-title">style.css — Visual Studio Code</span></div><div class="vscode-tabs"><div class="vscode-tab">index.html</div><div class="vscode-tab is-active">style.css</div></div><div class="vscode-body"><div class="vscode-gutter">1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+11
+12
+13
+14
+15
+16
+17
+18
+19
+20</div><code class="vscode-code"><span class="add"><span class="sy-com">/* ヘッダーの高さを決め、中のロゴを天地中央に置く */</span></span><span class="add"><span class="sy-sel">.header_contents</span> {</span><span class="add">  <span class="sy-attr">height</span>: <span class="sy-num">90px</span>;</span><span class="add">  <span class="sy-attr">display</span>: flex;</span><span class="add">  <span class="sy-attr">align-items</span>: center;</span><span class="add">}</span><span class="add"></span><span class="add"><span class="sy-sel">.logo</span> {</span><span class="add">  <span class="sy-attr">display</span>: flex;</span><span class="add">  <span class="sy-attr">align-items</span>: center;</span><span class="add">  <span class="sy-attr">font-size</span>: <span class="sy-num">20px</span>;</span><span class="add">  <span class="sy-attr">font-weight</span>: bold;</span><span class="add">  <span class="sy-attr">letter-spacing</span>: <span class="sy-num">1px</span>;</span><span class="add">}</span><span class="add"><span class="sy-sel">.logo img</span> {</span><span class="add">  <span class="sy-attr">width</span>: <span class="sy-num">40px</span>;</span><span class="add">  <span class="sy-attr">height</span>: <span class="sy-num">40px</span>;</span><span class="add">  <span class="sy-attr">border-radius</span>: <span class="sy-num">8px</span>;</span><span class="add">  <span class="sy-attr">margin-right</span>: <span class="sy-num">12px</span>;</span><span class="add">}</span></code></div></div>
+
+    <div class="note">
+      <span class="label">セレクタを2つ並べる書き方</span><br>
+      <code>.logo img</code> のように<strong>セレクタを半角スペースで並べる</strong>と、「<code>logo</code> の<strong>中にある</strong> <code>&lt;img&gt;</code>」という意味になります。ページ内の他の画像には影響せず、<code>logo</code> の中の画像だけに指定できます。
+    </div>
+
+    <div class="note">
+      <span class="label">補足</span><br>
+      <code>alt</code> 属性は、画像が表示できなかったときや読み上げ時に使われる「代わりのテキスト」です。ロゴマークのように装飾目的の画像では、あえて空（<code>alt=""</code>）にすることがあります。<br>
+      なお、<code>&lt;img&gt;</code> の <code>width</code>・<code>height</code> 属性は、読み込み前にレイアウトのガタつきを防ぐための目安です。実際の表示サイズはCSSの <code>.logo img</code> でも指定しており、両方書かれていても問題ありません。
+    </div>
+
+    <figure>
+      <div class="chrome"><div class="chrome-tabbar"><span class="win-dot red"></span><span class="win-dot yellow"></span><span class="win-dot green"></span><div class="chrome-tab">SAMPLE SITE</div></div><div class="chrome-toolbar"><span class="chrome-nav">←&nbsp;→&nbsp;⟳</span><div class="chrome-url">file:///mysite/index.html</div></div><div class="chrome-viewport" style="padding: 0;">
+        <div class="browser-demo demo-reset dm3">
+        <div class="header">
+          <div class="header_contents">
+            <div class="logo">
+              <img src="sample_site/images/logo_mark.webp" alt="" width="40" height="40">
+              SAMPLE SITE
+            </div>
+          </div>
+        </div>
+        </div>
+      </div></div>
+      <figcaption>制作の途中経過：header の logo 枠に <code>&lt;img&gt;</code> のロゴマークとサイト名を入れ、<code>flex</code> で横並びにした状態。</figcaption>
+    </figure>
+
+    <h3>枠に背景色をつける</h3>
+    <p>
+      枠の背景色は <code>background</code>（または <code>background-color</code>）プロパティで指定します。フッターの背景色（<code>#222</code>）はすでに指定してあるので、ここでは文字色を明るいグレー（<code>#bbb</code>）にし、<code>footer_contents</code> で高さと文字の配置を決めます。
+    </p>
+
+    <div class="vscode"><div class="vscode-titlebar"><span class="win-dot red"></span><span class="win-dot yellow"></span><span class="win-dot green"></span><span class="vscode-title">style.css — Visual Studio Code</span></div><div class="vscode-tabs"><div class="vscode-tab">index.html</div><div class="vscode-tab is-active">style.css</div></div><div class="vscode-body"><div class="vscode-gutter">1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+11</div><code class="vscode-code"><span class="sy-sel">.footer</span> {
+  <span class="sy-attr">background</span>: <span class="sy-num">#222</span>;
+<span class="add">  <span class="sy-attr">color</span>: #bbb;</span>}
+<span class="add"><span class="sy-sel">.footer_contents</span> {</span><span class="add">  <span class="sy-attr">height</span>: <span class="sy-num">90px</span>;</span><span class="add">  <span class="sy-attr">display</span>: flex;</span><span class="add">  <span class="sy-attr">align-items</span>: center;</span><span class="add">  <span class="sy-attr">justify-content</span>: center;</span><span class="add">  <span class="sy-attr">font-size</span>: <span class="sy-num">13px</span>;</span><span class="add">}</span></code></div></div>
+
+    <h3>背景画像を敷いて文字を重ねる</h3>
+    <p>
+      メインビジュアルのように「画像の上に文字を重ねたい」ときは、CSSの <code>background</code> プロパティで背景画像として配置します。ダウンロードした素材の <code>top_bg.webp</code> を使います。
+    </p>
+
+    <p>
+      まずHTML側で、<code>visual</code> の中に、重ねて表示する見出しを入れます。<code>&lt;h1&gt;</code> はページの大見出し、<code>&lt;br&gt;</code> は改行のタグです。前のページで <code>copy</code> という名前の枠に書いていた目印の文字は、この <code>&lt;h1&gt;</code> に置き換わります。
+    </p>
+
+    <div class="vscode"><div class="vscode-titlebar"><span class="win-dot red"></span><span class="win-dot yellow"></span><span class="win-dot green"></span><span class="vscode-title">index.html — Visual Studio Code</span></div><div class="vscode-tabs"><div class="vscode-tab is-active">index.html</div><div class="vscode-tab">style.css</div></div><div class="vscode-body"><div class="vscode-gutter">1
+2
+3</div><code class="vscode-code"><span class="add">&lt;<span class="sy-tag">div</span> <span class="sy-attr">class</span>=<span class="sy-str">"visual"</span>&gt;</span><span class="add">  &lt;<span class="sy-tag">h1</span> <span class="sy-attr">class</span>=<span class="sy-str">"copy"</span>&gt;Webの基礎を、&lt;<span class="sy-tag">br</span>&gt;手を動かして学ぶ。&lt;/<span class="sy-tag">h1</span>&gt;</span><span class="add">&lt;/<span class="sy-tag">div</span>&gt;</span></code></div></div>
+
+    <p>
+      次にCSS側で、<code>visual</code> の背景と、重ねた文字の見た目を指定します。
+    </p>
+
+    <div class="vscode"><div class="vscode-titlebar"><span class="win-dot red"></span><span class="win-dot yellow"></span><span class="win-dot green"></span><span class="vscode-title">style.css — Visual Studio Code</span></div><div class="vscode-tabs"><div class="vscode-tab">index.html</div><div class="vscode-tab is-active">style.css</div></div><div class="vscode-body"><div class="vscode-gutter">1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+11
+12
+13
+14</div><code class="vscode-code"><span class="add"><span class="sy-sel">.visual</span> {</span><span class="add">  <span class="sy-attr">height</span>: <span class="sy-num">360px</span>;</span><span class="add">  <span class="sy-attr">margin-top</span>: <span class="sy-num">32px</span>;</span><span class="add">  <span class="sy-attr">margin-bottom</span>: <span class="sy-num">40px</span>;</span><span class="add">  <span class="sy-attr">background</span>: url("../images/top_bg.webp") no-repeat center center;</span><span class="add">  <span class="sy-attr">display</span>: flex;</span><span class="add">  <span class="sy-attr">align-items</span>: center;</span><span class="add">}</span><span class="add"><span class="sy-sel">.copy</span> {</span><span class="add">  <span class="sy-attr">color</span>: #fff;</span><span class="add">  <span class="sy-attr">padding-left</span>: <span class="sy-num">56px</span>;</span><span class="add">  <span class="sy-attr">font-size</span>: <span class="sy-num">38px</span>;</span><span class="add">  <span class="sy-attr">line-height</span>: <span class="sy-num">1.3</span>;</span><span class="add">}</span></code></div></div>
+
+    <figure>
+      <div class="chrome"><div class="chrome-tabbar"><span class="win-dot red"></span><span class="win-dot yellow"></span><span class="win-dot green"></span><div class="chrome-tab">SAMPLE SITE</div></div><div class="chrome-toolbar"><span class="chrome-nav">←&nbsp;→&nbsp;⟳</span><div class="chrome-url">file:///mysite/index.html</div></div><div class="chrome-viewport" style="padding: 0;">
+        <div class="browser-demo demo-reset dm3">
+        <div class="header">
+          <div class="header_contents">
+            <div class="logo">
+              <img src="sample_site/images/logo_mark.webp" alt="" width="40" height="40">
+              SAMPLE SITE
+            </div>
+          </div>
+        </div>
+        <div class="contents">
+          <div class="visual">
+            <h1 class="copy">Webの基礎を、<br>手を動かして学ぶ。</h1>
+          </div>
+        </div>
+        </div>
+      </div></div>
+      <figcaption>制作の途中経過：visual の枠に背景画像を敷き、その上に <code>h1</code> の見出しを重ねた状態。</figcaption>
+    </figure>
+
+    <p>
+      いま指定した <code>background</code> は、<strong>画像の場所と表示のしかたをまとめて書ける</strong>プロパティです。中身を順番に見てみましょう。
+    </p>
+
+    <pre><code>background: url("../images/top_bg.webp") no-repeat center center;</code></pre>
+
+    <table>
+      <tr>
+        <th>指定</th>
+        <th>意味</th>
+      </tr>
+      <tr>
+        <td><code>url("../images/top_bg.webp")</code></td>
+        <td>背景に使う画像ファイルの場所</td>
+      </tr>
+      <tr>
+        <td><code>no-repeat</code></td>
+        <td>画像を繰り返さない（タイル表示しない）</td>
+      </tr>
+      <tr>
+        <td><code>center</code>（1つ目）</td>
+        <td>画像の左右の位置を中央にする</td>
+      </tr>
+      <tr>
+        <td><code>center</code>（2つ目）</td>
+        <td>画像の上下の位置を中央にする</td>
+      </tr>
+    </table>
+
+    <p>
+      2つの <code>center</code> が必要なのは、<strong>画像が枠より大きいと、はみ出した部分が切り取られる</strong>ためです。たとえば幅1,000px・高さ667pxの画像を、幅980px・高さ360pxの <code>visual</code> の枠に敷くと、画像の一部しか表示されません。<strong>そのときどこを切り取って見せるかを決めているのが <code>center center</code></strong> で、画像の中心が枠に収まります。
+    </p>
+
+    <div class="point">
+      <span class="label">理解ポイント</span><br>
+      パスの先頭にある <code>../</code>（ドットドットスラッシュ）は「1つ前のフォルダ」という意味です（<code>../</code> が無ければ「今いるフォルダの中」）。<code>style.css</code> は <code>css/</code> フォルダの中にあるので、<code>images/</code> に届くには <code>../</code> で1つ上（<code>index.html</code> のある階層）に戻る必要があります。<br>
+      同じロゴ画像でも、<strong>書き出す場所によってパスが変わります</strong>。HTMLの <code>src</code> は <code>index.html</code> から見て <code>images/logo_mark.webp</code>、CSSの <code>url</code> は <code>css/style.css</code> から見て <code>../images/…</code> です。
+    </div>
+  </section>
+
+
+  <!-- ============================================================
+       15. 枠の中にテキストとリストを入れる
+       ============================================================ -->
+  <section id="chapter19">
+    <h2>19. 枠の中にテキストとリストを入れる</h2>
+
+    <p>
+      次は、本文のテキストと、メニューのようなリストを枠の中に入れます。
+    </p>
+
+    <h3>テキストとメニューを横に並べる</h3>
+    <p>
+      本文とメニューに、実際の中身を入れていきます。前のページで目印として書いた「text」「menu」という文字は、これから入れる本文とリストに置き換わるので消します。
+    </p>
+    <div class="vscode"><div class="vscode-titlebar"><span class="win-dot red"></span><span class="win-dot yellow"></span><span class="win-dot green"></span><span class="vscode-title">index.html — Visual Studio Code</span></div><div class="vscode-tabs"><div class="vscode-tab is-active">index.html</div><div class="vscode-tab">style.css</div></div><div class="vscode-body"><div class="vscode-gutter">1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+11
+12
+13
+14
+15
+16</div><code class="vscode-code"><span class="add">&lt;<span class="sy-tag">div</span> <span class="sy-attr">class</span>=<span class="sy-str">"text_wrapper"</span>&gt;</span><span class="add">  &lt;<span class="sy-tag">div</span> <span class="sy-attr">class</span>=<span class="sy-str">"text"</span>&gt;</span><span class="add">    &lt;<span class="sy-tag">p</span>&gt;枠（ボックス）を組み立て、色や画像・テキストを入れて、</span><span class="add">       1つのWebサイトを完成させる流れを体験します。ブラウザ上の</span><span class="add">       あらゆる要素が「四角い枠」で構成されていることを学びましょう。&lt;/<span class="sy-tag">p</span>&gt;</span><span class="add">  &lt;/<span class="sy-tag">div</span>&gt;</span><span class="add">  &lt;<span class="sy-tag">div</span> <span class="sy-attr">class</span>=<span class="sy-str">"menu"</span>&gt;</span><span class="add">    &lt;<span class="sy-tag">ul</span>&gt;</span><span class="add">      &lt;<span class="sy-tag">li</span>&gt;ホーム&lt;/<span class="sy-tag">li</span>&gt;</span><span class="add">      &lt;<span class="sy-tag">li</span>&gt;レッスン&lt;/<span class="sy-tag">li</span>&gt;</span><span class="add">      &lt;<span class="sy-tag">li</span>&gt;入門&lt;/<span class="sy-tag">li</span>&gt;</span><span class="add">      &lt;<span class="sy-tag">li</span>&gt;基礎&lt;/<span class="sy-tag">li</span>&gt;</span><span class="add">      &lt;<span class="sy-tag">li</span>&gt;応用&lt;/<span class="sy-tag">li</span>&gt;</span><span class="add">    &lt;/<span class="sy-tag">ul</span>&gt;</span><span class="add">  &lt;/<span class="sy-tag">div</span>&gt;</span><span class="add">&lt;/<span class="sy-tag">div</span>&gt;</span></code></div></div>
+
+    <h3>リストのタグ</h3>
+    <p>
+      リストは、<code>&lt;li&gt;</code> タグ（1項目）を <code>&lt;ul&gt;</code> か <code>&lt;ol&gt;</code> のどちらかで必ず囲って作ります。
+    </p>
+
+    <table>
+      <tr>
+        <th>タグ</th>
+        <th>読み方・意味</th>
+        <th>マーカー</th>
+      </tr>
+      <tr>
+        <td><code>&lt;ul&gt;</code></td>
+        <td>unordered list（順序なしリスト）</td>
+        <td>「・」などの記号</td>
+      </tr>
+      <tr>
+        <td><code>&lt;ol&gt;</code></td>
+        <td>ordered list（順序ありリスト）</td>
+        <td>1, 2, 3 … の数字</td>
+      </tr>
+      <tr>
+        <td><code>&lt;li&gt;</code></td>
+        <td>list item（リストの1項目）</td>
+        <td>―</td>
+      </tr>
+    </table>
+
+    <div class="note">
+      <span class="label">補足</span><br>
+      別のページへ移動させたいときは <code>&lt;a&gt;</code> タグ（リンク）を使います。書き方は <code>&lt;a href="移動先のファイル名"&gt;表示する文字&lt;/a&gt;</code> で、<code>href</code> 属性に移動先を指定します。メニューの各項目をページに繋ぐときは、<code>&lt;li&gt;</code> の中身を <code>&lt;a&gt;</code> で囲みます。<code>&lt;li&gt;ホーム&lt;/li&gt;</code> → <code>&lt;li&gt;&lt;a href="page1.html"&gt;ホーム&lt;/a&gt;&lt;/li&gt;</code> のようになります。
+    </div>
+
+    <h3>リストのCSS</h3>
+    <p>
+      リストの先頭には、標準で「●」のマーカーが付きます。このマーカーは <code>list-style-type</code> プロパティで変更できます。
+    </p>
+
+    <table>
+      <tr>
+        <th>値</th>
+        <th><code>list-style-type</code> での見え方</th>
+      </tr>
+      <tr>
+        <td><code>none</code></td>
+        <td>マーカーを表示しない</td>
+      </tr>
+      <tr>
+        <td><code>disc</code></td>
+        <td>●（黒丸）</td>
+      </tr>
+      <tr>
+        <td><code>circle</code></td>
+        <td>○（白丸）</td>
+      </tr>
+      <tr>
+        <td><code>decimal</code></td>
+        <td>1, 2, 3 …（数字）</td>
+      </tr>
+    </table>
+
+    <div class="vscode"><div class="vscode-titlebar"><span class="win-dot red"></span><span class="win-dot yellow"></span><span class="win-dot green"></span><span class="vscode-title">style.css — Visual Studio Code</span></div><div class="vscode-tabs"><div class="vscode-tab">index.html</div><div class="vscode-tab is-active">style.css</div></div><div class="vscode-body"><div class="vscode-gutter">1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+11
+12
+13
+14
+15
+16
+17</div><code class="vscode-code"><span class="sy-sel">.text_wrapper</span> {
+  <span class="sy-attr">display</span>: flex;
+  <span class="sy-attr">justify-content</span>: center;
+<span class="add">  <span class="sy-attr">margin-bottom</span>: <span class="sy-num">44px</span>;</span>}
+<span class="add"><span class="sy-sel">.text</span> {</span><span class="add">  <span class="sy-attr">width</span>: <span class="sy-num">560px</span>;</span><span class="add">  <span class="sy-attr">padding-right</span>: <span class="sy-num">40px</span>;</span><span class="add">  <span class="sy-attr">border-right</span>: <span class="sy-num">1px</span> solid #ddd;</span><span class="add">  <span class="sy-attr">line-height</span>: <span class="sy-num">1.9</span>;</span><span class="add">  <span class="sy-attr">color</span>: <span class="sy-num">#555</span>;</span><span class="add">}</span><span class="add"><span class="sy-sel">.menu</span> {</span><span class="add">  <span class="sy-attr">width</span>: <span class="sy-num">240px</span>;</span><span class="add">  <span class="sy-attr">padding-left</span>: <span class="sy-num">40px</span>;</span><span class="add">  <span class="sy-attr">line-height</span>: <span class="sy-num">1.9</span>;</span>}</code></div></div>
+
+    <figure>
+      <div class="chrome"><div class="chrome-tabbar"><span class="win-dot red"></span><span class="win-dot yellow"></span><span class="win-dot green"></span><div class="chrome-tab">SAMPLE SITE</div></div><div class="chrome-toolbar"><span class="chrome-nav">←&nbsp;→&nbsp;⟳</span><div class="chrome-url">file:///mysite/index.html</div></div><div class="chrome-viewport" style="padding: 0;">
+        <div class="browser-demo demo-reset dm3">
+        <div class="header">
+          <div class="header_contents">
+            <div class="logo">
+              <img src="sample_site/images/logo_mark.webp" alt="" width="40" height="40">
+              SAMPLE SITE
+            </div>
+          </div>
+        </div>
+        <div class="contents">
+          <div class="visual">
+            <h1 class="copy">Webの基礎を、<br>手を動かして学ぶ。</h1>
+          </div>
+          <div class="text_wrapper">
+            <div class="text">
+              <p>枠（ボックス）を組み立て、色や画像・テキストを入れて、
+                 1つのWebサイトを完成させる流れを体験します。ブラウザ上の
+                 あらゆる要素が「四角い枠」で構成されていることを学びましょう。</p>
+            </div>
+            <div class="menu">
+              <ul>
+                <li>ホーム</li>
+                <li>レッスン</li>
+                <li>入門</li>
+                <li>基礎</li>
+                <li>応用</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+        </div>
+      </div></div>
+      <figcaption>制作の途中経過：text_wrapper の中に紹介文（text）とメニュー（ul/li）を入れ、<code>flex</code> で横並びにした状態。</figcaption>
+    </figure>
+
+  </section>
+
+
+  <!-- ============================================================
+       16. シンプルなWebサイトの完成
+       ============================================================ -->
+  <section id="chapter20">
+    <h2>20. シンプルなWebサイトの完成</h2>
+
+    <p>
+      枠の中に画像・色・テキスト・リストがすべて入りました。最後に、HTMLの先頭を整えて完成させます。
+    </p>
+
+    <h3>完成版 HTML</h3>
+    <p>
+      完成版では、<code>&lt;head&gt;</code> のまわりに次の4つを追加しています。どれも「ページの設定」を書く部分で、実際のWebサイトではほぼ必ず入れるものです。
+    </p>
+    <ul>
+      <li><code>&lt;!DOCTYPE html&gt;</code> … このファイルがHTMLであることをブラウザに伝える宣言。1行目に書きます</li>
+      <li><code>lang="ja"</code> … ページの言語が日本語であることを示す指定</li>
+      <li><code>&lt;meta charset="UTF-8"&gt;</code> … 文字コードの指定。これが無いと日本語が文字化けすることがあります</li>
+      <li><code>&lt;meta name="viewport" ...&gt;</code> … スマートフォンで正しい大きさで表示するための指定</li>
+    </ul>
+    <p>
+      あわせて、<code>&lt;title&gt;</code> を「練習」からサイト名の「SAMPLE SITE」に変えています。ここに書いた文字が、ブラウザのタブに表示されます。
+    </p>
+    <div class="vscode"><div class="vscode-titlebar"><span class="win-dot red"></span><span class="win-dot yellow"></span><span class="win-dot green"></span><span class="vscode-title">index.html — Visual Studio Code</span></div><div class="vscode-tabs"><div class="vscode-tab is-active">index.html</div><div class="vscode-tab">style.css</div></div><div class="vscode-body"><div class="vscode-gutter">1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+11
+12
+13
+14
+15
+16
+17
+18
+19
+20
+21
+22
+23
+24
+25
+26
+27
+28
+29
+30
+31
+32
+33
+34
+35
+36
+37
+38
+39
+40
+41
+42
+43
+44
+45
+46
+47
+48</div><code class="vscode-code">&lt;!DOCTYPE html&gt;
+&lt;<span class="sy-tag">html</span> <span class="sy-attr">lang</span>=<span class="sy-str">"ja"</span>&gt;
+&lt;<span class="sy-tag">head</span>&gt;
+  &lt;<span class="sy-tag">meta</span> <span class="sy-attr">charset</span>=<span class="sy-str">"UTF-8"</span> /&gt;
+  &lt;<span class="sy-tag">meta</span> <span class="sy-attr">name</span>=<span class="sy-str">"viewport"</span> <span class="sy-attr">content</span>=<span class="sy-str">"width=device-width, initial-scale=1.0"</span> /&gt;
+  &lt;<span class="sy-tag">title</span>&gt;SAMPLE SITE&lt;/<span class="sy-tag">title</span>&gt;
+  &lt;<span class="sy-tag">link</span> <span class="sy-attr">href</span>=<span class="sy-str">"css/style.css"</span> <span class="sy-attr">rel</span>=<span class="sy-str">"stylesheet"</span>&gt;
+&lt;/<span class="sy-tag">head</span>&gt;
+&lt;<span class="sy-tag">body</span>&gt;
+
+  &lt;<span class="sy-tag">div</span> <span class="sy-attr">class</span>=<span class="sy-str">"header"</span>&gt;
+    &lt;<span class="sy-tag">div</span> <span class="sy-attr">class</span>=<span class="sy-str">"header_contents"</span>&gt;
+      &lt;<span class="sy-tag">div</span> <span class="sy-attr">class</span>=<span class="sy-str">"logo"</span>&gt;
+        &lt;<span class="sy-tag">img</span> <span class="sy-attr">src</span>=<span class="sy-str">"images/logo_mark.webp"</span> <span class="sy-attr">alt</span>=<span class="sy-str">""</span> <span class="sy-attr">width</span>=<span class="sy-str">"40"</span> <span class="sy-attr">height</span>=<span class="sy-str">"40"</span>&gt;
+        SAMPLE SITE
+      &lt;/<span class="sy-tag">div</span>&gt;
+    &lt;/<span class="sy-tag">div</span>&gt;
+  &lt;/<span class="sy-tag">div</span>&gt;
+
+  &lt;<span class="sy-tag">div</span> <span class="sy-attr">class</span>=<span class="sy-str">"contents"</span>&gt;
+    &lt;<span class="sy-tag">div</span> <span class="sy-attr">class</span>=<span class="sy-str">"visual"</span>&gt;
+      &lt;<span class="sy-tag">h1</span> <span class="sy-attr">class</span>=<span class="sy-str">"copy"</span>&gt;Webの基礎を、&lt;<span class="sy-tag">br</span>&gt;手を動かして学ぶ。&lt;/<span class="sy-tag">h1</span>&gt;
+    &lt;/<span class="sy-tag">div</span>&gt;
+
+    &lt;<span class="sy-tag">div</span> <span class="sy-attr">class</span>=<span class="sy-str">"text_wrapper"</span>&gt;
+      &lt;<span class="sy-tag">div</span> <span class="sy-attr">class</span>=<span class="sy-str">"text"</span>&gt;
+        &lt;<span class="sy-tag">p</span>&gt;枠（ボックス）を組み立て、色や画像・テキストを入れて、
+           1つのWebサイトを完成させる流れを体験します。ブラウザ上の
+           あらゆる要素が「四角い枠」で構成されていることを学びましょう。&lt;/<span class="sy-tag">p</span>&gt;
+      &lt;/<span class="sy-tag">div</span>&gt;
+      &lt;<span class="sy-tag">div</span> <span class="sy-attr">class</span>=<span class="sy-str">"menu"</span>&gt;
+        &lt;<span class="sy-tag">ul</span>&gt;
+          &lt;<span class="sy-tag">li</span>&gt;ホーム&lt;/<span class="sy-tag">li</span>&gt;
+          &lt;<span class="sy-tag">li</span>&gt;レッスン&lt;/<span class="sy-tag">li</span>&gt;
+          &lt;<span class="sy-tag">li</span>&gt;入門&lt;/<span class="sy-tag">li</span>&gt;
+          &lt;<span class="sy-tag">li</span>&gt;基礎&lt;/<span class="sy-tag">li</span>&gt;
+          &lt;<span class="sy-tag">li</span>&gt;応用&lt;/<span class="sy-tag">li</span>&gt;
+        &lt;/<span class="sy-tag">ul</span>&gt;
+      &lt;/<span class="sy-tag">div</span>&gt;
+    &lt;/<span class="sy-tag">div</span>&gt;
+  &lt;/<span class="sy-tag">div</span>&gt;
+
+  &lt;<span class="sy-tag">div</span> <span class="sy-attr">class</span>=<span class="sy-str">"footer"</span>&gt;
+    &lt;<span class="sy-tag">div</span> <span class="sy-attr">class</span>=<span class="sy-str">"footer_contents"</span>&gt;© SAMPLE SITE&lt;/<span class="sy-tag">div</span>&gt;
+  &lt;/<span class="sy-tag">div</span>&gt;
+
+&lt;/<span class="sy-tag">body</span>&gt;
+&lt;/<span class="sy-tag">html</span>&gt;</code></div></div>
+
+    <h3>完成版 CSS</h3>
+    <div class="vscode"><div class="vscode-titlebar"><span class="win-dot red"></span><span class="win-dot yellow"></span><span class="win-dot green"></span><span class="vscode-title">style.css — Visual Studio Code</span></div><div class="vscode-tabs"><div class="vscode-tab">index.html</div><div class="vscode-tab is-active">style.css</div></div><div class="vscode-body"><div class="vscode-gutter">1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+11
+12
+13
+14
+15
+16
+17
+18
+19
+20
+21
+22
+23
+24
+25
+26
+27
+28
+29
+30
+31
+32
+33
+34
+35
+36
+37
+38
+39
+40
+41
+42
+43
+44
+45
+46
+47
+48
+49
+50
+51
+52
+53
+54
+55
+56
+57
+58
+59
+60
+61
+62
+63
+64
+65
+66
+67
+68
+69
+70
+71
+72
+73
+74
+75
+76
+77
+78
+79
+80
+81
+82
+83
+84
+85
+86
+87
+88
+89</div><code class="vscode-code"><span class="sy-sel">*</span> {
+  <span class="sy-attr">box-sizing</span>: border-box;
+  <span class="sy-attr">margin</span>: <span class="sy-num">0</span>;
+  <span class="sy-attr">padding</span>: <span class="sy-num">0</span>;
+}
+<span class="sy-sel">body</span> {
+  <span class="sy-attr">font-family</span>: "Helvetica Neue", Arial, "Hiragino Sans", Meiryo, sans-serif;
+  <span class="sy-attr">color</span>: <span class="sy-num">#333</span>;
+  <span class="sy-attr">background</span>: #fff;
+}
+
+<span class="sy-com">/* 中身は 980px に固定して中央寄せ（全幅の帯の中に置く） */</span>
+.header_contents,
+.contents,
+<span class="sy-sel">.footer_contents</span> {
+  <span class="sy-attr">width</span>: <span class="sy-num">980px</span>;
+  <span class="sy-attr">margin</span>: <span class="sy-num">0</span> auto;
+}
+
+<span class="sy-com">/* ヘッダー：全幅（下線が画面端まで伸びる）／中身は header_contents で中央寄せ */</span>
+<span class="sy-sel">.header</span> {
+  <span class="sy-attr">border-bottom</span>: <span class="sy-num">1px</span> solid #eee;
+}
+<span class="sy-sel">.header_contents</span> {
+  <span class="sy-attr">height</span>: <span class="sy-num">90px</span>;
+  <span class="sy-attr">display</span>: flex;
+  <span class="sy-attr">align-items</span>: center;
+}
+<span class="sy-sel">.logo</span> {
+  <span class="sy-attr">display</span>: flex;
+  <span class="sy-attr">align-items</span>: center;
+  <span class="sy-attr">font-size</span>: <span class="sy-num">20px</span>;
+  <span class="sy-attr">font-weight</span>: bold;
+  <span class="sy-attr">letter-spacing</span>: <span class="sy-num">1px</span>;
+}
+<span class="sy-sel">.logo img</span> {
+  <span class="sy-attr">width</span>: <span class="sy-num">40px</span>;
+  <span class="sy-attr">height</span>: <span class="sy-num">40px</span>;
+  <span class="sy-attr">border-radius</span>: <span class="sy-num">8px</span>;
+  <span class="sy-attr">margin-right</span>: <span class="sy-num">12px</span>;
+}
+
+<span class="sy-com">/* ビジュアル：背景画像を敷いて、その上に文字を重ねる */</span>
+<span class="sy-sel">.visual</span> {
+  <span class="sy-attr">height</span>: <span class="sy-num">360px</span>;
+  <span class="sy-attr">margin-top</span>: <span class="sy-num">32px</span>;
+  <span class="sy-attr">margin-bottom</span>: <span class="sy-num">40px</span>;
+  <span class="sy-attr">background</span>: url("../images/top_bg.webp") no-repeat center center;
+  <span class="sy-attr">display</span>: flex;
+  <span class="sy-attr">align-items</span>: center;
+}
+<span class="sy-sel">.copy</span> {
+  <span class="sy-attr">color</span>: #fff;
+  <span class="sy-attr">padding-left</span>: <span class="sy-num">56px</span>;
+  <span class="sy-attr">font-size</span>: <span class="sy-num">38px</span>;
+  <span class="sy-attr">line-height</span>: <span class="sy-num">1.3</span>;
+}
+
+<span class="sy-com">/* テキスト＋メニュー：flexで横並び */</span>
+<span class="sy-sel">.text_wrapper</span> {
+  <span class="sy-attr">display</span>: flex;
+  <span class="sy-attr">justify-content</span>: center;
+  <span class="sy-attr">margin-bottom</span>: <span class="sy-num">44px</span>;
+}
+<span class="sy-sel">.text</span> {
+  <span class="sy-attr">width</span>: <span class="sy-num">560px</span>;
+  <span class="sy-attr">padding-right</span>: <span class="sy-num">40px</span>;
+  <span class="sy-attr">border-right</span>: <span class="sy-num">1px</span> solid #ddd;
+  <span class="sy-attr">line-height</span>: <span class="sy-num">1.9</span>;
+  <span class="sy-attr">color</span>: <span class="sy-num">#555</span>;
+}
+<span class="sy-sel">.menu</span> {
+  <span class="sy-attr">width</span>: <span class="sy-num">240px</span>;
+  <span class="sy-attr">padding-left</span>: <span class="sy-num">40px</span>;
+  <span class="sy-attr">line-height</span>: <span class="sy-num">1.9</span>;
+}
+
+<span class="sy-com">/* フッター：全幅（暗色帯が画面端まで）／中身は footer_contents で中央寄せ */</span>
+<span class="sy-sel">.footer</span> {
+  <span class="sy-attr">background</span>: <span class="sy-num">#222</span>;
+  <span class="sy-attr">color</span>: #bbb;
+}
+<span class="sy-sel">.footer_contents</span> {
+  <span class="sy-attr">height</span>: <span class="sy-num">90px</span>;
+  <span class="sy-attr">display</span>: flex;
+  <span class="sy-attr">align-items</span>: center;
+  <span class="sy-attr">justify-content</span>: center;
+  <span class="sy-attr">font-size</span>: <span class="sy-num">13px</span>;
+}</code></div></div>
+
+    <h3>完成イメージ</h3>
+    <p>
+      すべてのコードを反映すると、次のような「SAMPLE SITE」が表示されます。
+    </p>
+
+    <div class="chrome"><div class="chrome-tabbar"><span class="win-dot red"></span><span class="win-dot yellow"></span><span class="win-dot green"></span><div class="chrome-tab">SAMPLE SITE</div></div><div class="chrome-toolbar"><span class="chrome-nav">←&nbsp;→&nbsp;⟳</span><div class="chrome-url">file:///mysite/index.html</div></div><div class="chrome-viewport" style="padding: 0;">
+        <div class="browser-demo demo-reset dm3">
+        <div class="header">
+          <div class="header_contents">
+            <div class="logo">
+              <img src="sample_site/images/logo_mark.webp" alt="" width="40" height="40">
+              SAMPLE SITE
+            </div>
+          </div>
+        </div>
+        <div class="contents">
+          <div class="visual">
+            <h1 class="copy">Webの基礎を、<br>手を動かして学ぶ。</h1>
+          </div>
+          <div class="text_wrapper">
+            <div class="text">
+              <p>枠（ボックス）を組み立て、色や画像・テキストを入れて、
+                 1つのWebサイトを完成させる流れを体験します。ブラウザ上の
+                 あらゆる要素が「四角い枠」で構成されていることを学びましょう。</p>
+            </div>
+            <div class="menu">
+              <ul>
+                <li>ホーム</li>
+                <li>レッスン</li>
+                <li>入門</li>
+                <li>基礎</li>
+                <li>応用</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+        <div class="footer">
+          <div class="footer_contents">© SAMPLE SITE</div>
+        </div>
+        </div>
+      </div></div>
+
+    <div class="open-site-wrap">
+      <a class="open-site" href="sample_site/stage2_simple.html" target="_blank" rel="noopener">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h6"/></svg>
+        実際のサンプルサイトを開く（新しいタブ）
+      </a>
+    </div>
+
+    <h3>使ったCSSプロパティ集計</h3>
+    <p>
+      このシンプルなWebサイトで使ったCSSプロパティと、その使用回数をまとめると次のとおりです。<code>margin-top</code> のように向きを指定するものは、<code>margin</code> のまとまりとして数えています。
+    </p>
+
+    <table>
+      <tr>
+        <th>プロパティ</th>
+        <th>使用回数</th>
+      </tr>
+      <tr><td><code>margin</code></td><td>6</td></tr>
+      <tr><td><code>display</code></td><td>5</td></tr>
+      <tr><td><code>font</code></td><td>5</td></tr>
+      <tr><td><code>align-items</code></td><td>4</td></tr>
+      <tr><td><code>color</code></td><td>4</td></tr>
+      <tr><td><code>height</code></td><td>4</td></tr>
+      <tr><td><code>padding</code></td><td>4</td></tr>
+      <tr><td><code>width</code></td><td>4</td></tr>
+      <tr><td><code>background</code></td><td>3</td></tr>
+      <tr><td><code>border</code></td><td>3</td></tr>
+      <tr><td><code>line-height</code></td><td>3</td></tr>
+      <tr><td><code>justify-content</code></td><td>2</td></tr>
+      <tr><td><code>box-sizing</code></td><td>1</td></tr>
+      <tr><td><code>letter-spacing</code></td><td>1</td></tr>
+    </table>
+
+    <p>
+      ここまでのページは、<strong>14種類</strong>のプロパティの組み合わせでできています。
+    </p>
+
+    <h3>コーディングのおさらい</h3>
+    <p>
+      前のページからここまでで行ってきた制作の流れを、あらためて5つのステップにまとめます。どんなサイトを作るときも、基本はこの順番の繰り返しです。
+    </p>
+    <ol>
+      <li>紙に線で枠を書く</li>
+      <li>枠に名前をつける</li>
+      <li>HTMLにクラス名をつけてマークアップする</li>
+      <li>CSSでセレクタに余白やサイズを記入し、枠だけのデザインを完成させる</li>
+      <li>枠の中にテキストや画像といった要素を入れていく</li>
+    </ol>
+    <p>
+      前のページ（コーダー初級#2）が <strong>ステップ1〜4</strong>、このページが <strong>ステップ5</strong> にあたります。
+    </p>
+  </section>
+
+</main>
+
+<nav class="page-nav">
+  <a class="page-prev" href="beginner_2.html">
+    <span class="page-nav-label">前のページ</span>
+    <span class="page-nav-title">コーダー初級#2</span>
+    <span class="page-nav-sub">枠を組み立ててレイアウトを作る</span>
+  </a>
+  <a class="page-next" href="beginner_4.html">
+    <span class="page-nav-label">次のページ</span>
+    <span class="page-nav-title">コーダー初級#4</span>
+    <span class="page-nav-sub">レイアウトを拡張する</span>
+  </a>
+</nav>
+
+<footer>
+</footer>
+
+
+<script>
+  // ライブデモ（.browser-demo）を chrome 枠の幅にフィットさせる
+  (function () {
+    function fit() {
+      document.querySelectorAll('.browser-demo').forEach(function (d) {
+        d.style.zoom = d.parentElement.clientWidth / 1160;
+      });
+    }
+    window.addEventListener('load', fit);
+    window.addEventListener('resize', fit);
+  })();
+</script>
+
+<!-- ▼ 共通スクリプト。章ナビ・コピーボタン・先頭へ戻るが自動で付く（編集不要） -->
+<script src="../js/training.js"></script>
+</body>
+</html>

--- a/docs/training/css/beginner_3.css
+++ b/docs/training/css/beginner_3.css
@@ -1,0 +1,209 @@
+/* ============================================================
+   コーダー初級#3（beginner_3.html）専用のスタイル
+
+   全ページ共通の土台は training.css にあります。
+   ここに置くのは、このページだけで使う図やデモのスタイルです。
+   ============================================================ */
+
+/* ── 素材のダウンロードボタン ── */
+.dl-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: #2563eb;
+  color: #fff;
+  font-weight: 700;
+  font-size: 15px;
+  line-height: 1;
+  padding: 11px 18px;
+  border-radius: 8px;
+  text-decoration: none;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+.dl-btn:hover {
+  background: #1d4ed8;
+  text-decoration: none;
+}
+.dl-btn svg {
+  width: 18px;
+  height: 18px;
+  display: block;
+}
+.dl-note {
+  margin-left: 10px;
+  font-size: 14px;
+  color: #64748b;
+}
+
+/* ── サンプルサイトを開くリンク（アウトラインボタン） ── */
+.open-site-wrap {
+  text-align: center;
+  margin: 14px 0 4px;
+}
+.open-site {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 9px 16px;
+  border: 1.5px solid #2563eb;
+  border-radius: 8px;
+  color: #2563eb;
+  font-weight: 700;
+  font-size: 14px;
+  text-decoration: none;
+  background: #fff;
+}
+.open-site:hover {
+  background: #eff6ff;
+  text-decoration: none;
+}
+.open-site svg {
+  width: 16px;
+  height: 16px;
+}
+
+/* ── ライブデモの表示枠 ──
+   実寸（幅1160pxのウィンドウ相当）で組み、zoom で枠内に縮小表示する。
+   zoom の値はページ末尾のフィットスクリプトが上書きする。 */
+.browser-demo {
+  width: 1160px;
+  zoom: 0.72;
+  background: #fff;
+  padding: 8px;  /* ブラウザ既定の body 余白（8px）の再現 */
+}
+.browser-demo * {
+  box-sizing: content-box;
+}
+
+/* リセット前のブラウザ既定に合わせる */
+.browser-demo.demo-reset {
+  padding: 0;
+}
+
+/* * { margin: 0 } リセット済みのページ用 */
+.browser-demo.demo-reset * {
+  box-sizing: border-box;
+}
+
+/* デモ内は教材ページ側の見出し・段落装飾を打ち消してブラウザ既定に戻す */
+.browser-demo :is(h1,
+h2,
+h3,
+h4,
+h5,
+h6) {
+  margin: revert;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: inherit;
+  letter-spacing: normal;
+  font-size: revert;
+  font-weight: revert;
+  line-height: revert;
+}
+.browser-demo p {
+  margin: revert;
+}
+.browser-demo.demo-reset :is(h1,
+h2,
+h3,
+h4,
+h5,
+h6),
+.browser-demo.demo-reset p {
+  margin: 0;
+}
+
+/* ── ライブデモ用：完成CSS（css/style.css）を .dm3 スコープで再現 ──
+   教材のコードを変更したら、ここも合わせて更新すること */
+.dm3 * {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+.dm3 {
+  font-family: "Helvetica Neue", Arial, "Hiragino Sans", Meiryo, sans-serif;
+  color: #333;
+  background: #fff;
+}
+
+/* 中身は 980px に固定して中央寄せ（全幅の帯の中に置く） */
+.dm3 .header_contents,
+.dm3 .contents,
+.dm3 .footer_contents {
+  width: 980px;
+  margin: 0 auto;
+}
+
+/* ヘッダー：全幅（下線が画面端まで伸びる）／中身は header_contents で中央寄せ */
+.dm3 .header {
+  border-bottom: 1px solid #eee;
+}
+.dm3 .header_contents {
+  height: 90px;
+  display: flex;
+  align-items: center;
+}
+.dm3 .logo {
+  display: flex;
+  align-items: center;
+  font-size: 20px;
+  font-weight: bold;
+  letter-spacing: 1px;
+}
+.dm3 .logo img {
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+  margin-right: 12px;
+}
+
+/* ビジュアル：背景画像を敷いて、その上に文字を重ねる */
+.dm3 .visual {
+  height: 360px;
+  margin-top: 32px;
+  margin-bottom: 40px;
+  background: url("../cbc_internal/sample_site/images/top_bg.webp") no-repeat center center;
+  display: flex;
+  align-items: center;
+}
+.dm3 .copy {
+  color: #fff;
+  padding-left: 56px;
+  font-size: 38px;
+  line-height: 1.3;
+}
+
+/* テキスト＋メニュー：flexで横並び */
+.dm3 .text_wrapper {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 44px;
+}
+.dm3 .text {
+  width: 560px;
+  padding-right: 40px;
+  border-right: 1px solid #ddd;
+  line-height: 1.9;
+  color: #555;
+}
+.dm3 .menu {
+  width: 240px;
+  padding-left: 40px;
+  line-height: 1.9;
+}
+
+/* フッター：全幅（暗色帯が画面端まで）／中身は footer_contents で中央寄せ */
+.dm3 .footer {
+  background: #222;
+  color: #bbb;
+}
+.dm3 .footer_contents {
+  height: 90px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+}
+


### PR DESCRIPTION
## 概要

3セクション構成です（18〜20章）。

18. 枠の中に画像や色を入れる
19. 枠の中にテキストとリストを入れる
20. シンプルなWebサイトの完成

beginner_2.html で作った「枠だけのページ」に中身を入れて、1つのサイトとして完成させます。

- 見本は画像ではなくライブデモ
- 前ページの確認用スタイルを片付ける手順を冒頭に記述
  枠線・幅・高さ・余白は枠の位置を確認するための一時的な指定なので、
  中身を入れる段階で削除するように明示しています。

## ファイル

新規追加のみで、既存ファイルの変更はありません。

- docs/training/cbc_internal/beginner_3.html
- docs/training/css/beginner_3.css

## 補足

見本サイトと素材（sample_site/）は beginner_2.html のPRに含めています。
そのためベースを feature/mizuno/beginner_p2 にしています。
そちらのマージ後、ベースを feature/null-n/beginner_p1 に付け替えます。

完成コードは sample_site/stage2_simple.html と css/stage2.css として作成しています。
