### PR TITLE
コーダー初級#4 の教材ページを追加

### DIFF
--- a/docs/training/cbc_internal/beginner_4.html
+++ b/docs/training/cbc_internal/beginner_4.html
@@ -1,0 +1,872 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>コーダー初級#4</title>
+  <link rel="stylesheet" href="../css/training.css" />
+
+  <!-- ▼ このページ専用のスタイル -->
+  <link rel="stylesheet" href="../css/beginner_4.css" />
+
+  <!-- ▼ 開いたときに、ページの先頭から読み始められるようにする。
+       ブラウザが前回の位置へ戻すより先に動かす必要があるため、
+       training.js とは分けて <head> で読み込んでいる -->
+  <script src="../js/scroll-reset.js"></script>
+</head>
+<body>
+
+<header>
+  <div class="header-inner">
+    <h1>コーダー初級#4</h1>
+  </div>
+</header>
+
+<main>
+
+  <section class="toc" id="top">
+    <h2>目次</h2>
+
+    <ol start="21">
+      <li><a href="#chapter21">完成したレイアウトを拡張する</a></li>
+      <li><a href="#chapter22">素材画像を準備する</a></li>
+      <li><a href="#chapter23">完成コードと表示イメージ</a></li>
+    </ol>
+  </section>
+
+
+  <section id="chapter21">
+    <h2>21. 完成したレイアウトを拡張する</h2>
+
+    <p class="lead">
+      前回までで、ヘッダー・メインビジュアル・フッターという基本のレイアウトが完成しました。今回は、この完成したレイアウトを土台にして、実際のWebサイトに近い形へ拡張していきます。
+    </p>
+
+    <p>
+      すでにある枠組みを壊さずに、部品を足していくのがこの回のテーマです。追加するのは次の3つです。
+    </p>
+
+    <h3>3つの拡張目標</h3>
+    <ol>
+      <li><strong>ヘッダーにナビゲーションを追加する</strong>（メニューのリンクを横並びにする）</li>
+      <li><strong>コンテンツ内容を増やす</strong>（レッスンカードとキャッチコピーを追加する）</li>
+      <li><strong>フッターにリンク集を追加する</strong>（複数カラムのリンクを並べる）</li>
+    </ol>
+
+  </section>
+
+
+  <section id="chapter22">
+    <h2>22. 素材画像を準備する</h2>
+
+    <p>
+      拡張したサイトでは、ロゴやレッスンカードのサムネイルなどの画像を表示します。実際の制作では、画像素材をプロジェクト内の <code>images</code> フォルダにまとめて置きます。<br>
+前ページでダウンロードした <code>images.zip</code> には、<strong>レッスンカードのサムネイル3枚（HTML &amp; CSS / JavaScript / PHP）</strong>も含まれています。まだ配置していない場合は、下のボタンからダウンロードし、展開して出てきた <code>images</code> フォルダを <code>index.html</code> と同じ場所に置きましょう。
+    </p>
+
+    <p>
+      <a class="dl-btn" href="sample_site/images.zip">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12"/><path d="m7 10 5 5 5-5"/><path d="M5 21h14"/></svg>images.zip をダウンロード
+      </a><span class="dl-note">ロゴ・カードのサムネイル画像の素材一式</span>
+    </p>
+
+    <h3>フォルダ構成</h3>
+
+    <pre><code>mysite/
+├── index.html
+├── css/
+│   └── style.css
+└── images/
+    ├── logo_mark.webp   ← ロゴ画像
+    ├── top_bg.webp      ← メインビジュアルの背景画像
+    ├── card_html.webp   ← レッスンカード（HTML &amp; CSS）
+    ├── card_js.webp     ← レッスンカード（JavaScript）
+    └── card_php.webp    ← レッスンカード（PHP）</code></pre>
+
+    <div class="caution">
+      <span class="label">注意</span><br>
+<code>index.html</code> と同じ階層に <code>images</code> フォルダがある場合、HTML からは <code>&lt;img src="images/ファイル名"&gt;</code> と書きます。フォルダ名やファイル名が1文字でも違うと画像は表示されません。
+    </div>
+  </section>
+
+
+  <section id="chapter23">
+    <h2>23. 完成コードと表示イメージ</h2>
+
+    <p>
+      21章で挙げた3つの拡張をすべて反映すると、拡張版のサイトが完成します。以下の <code>index.html</code> と <code>css/style.css</code> の全体を、どこに何が追加されたかを確認しながら読み進めましょう。<br>
+      前ページから変えているのは<strong>ヘッダーとフッターの2か所</strong>です。<strong>ヘッダー</strong>は、ロゴとナビを左右の端に分けるため <code>header_contents</code> に <code>justify-content: space-between;</code> を足しています。<strong>フッター</strong>は、1行だった <code>footer_contents</code> を3カラムに組み替えました。それに伴い、高さ指定をやめて <code>space-around</code> に変え、<code>.footer</code> に <code>padding: 40px 0;</code> を足しています。それ以外は前ページのままです。
+    </p>
+
+    <h3>index.html（全体）</h3>
+    <div class="vscode"><div class="vscode-titlebar"><span class="win-dot red"></span><span class="win-dot yellow"></span><span class="win-dot green"></span><span class="vscode-title">index.html — Visual Studio Code</span></div><div class="vscode-tabs"><div class="vscode-tab is-active">index.html</div><div class="vscode-tab">style.css</div></div><div class="vscode-body"><div class="vscode-gutter">1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+11
+12
+13
+14
+15
+16
+17
+18
+19
+20
+21
+22
+23
+24
+25
+26
+27
+28
+29
+30
+31
+32
+33
+34
+35
+36
+37
+38
+39
+40
+41
+42
+43
+44
+45
+46
+47
+48
+49
+50
+51
+52
+53
+54
+55
+56
+57
+58
+59
+60
+61
+62
+63
+64
+65
+66
+67
+68
+69
+70
+71
+72
+73
+74
+75
+76
+77
+78
+79
+80
+81
+82
+83
+84
+85
+86
+87
+88
+89
+90
+91
+92
+93
+94
+95
+96
+97
+98
+99
+100
+101
+102
+103
+104
+105
+106
+107
+108
+109
+110
+111
+112
+113
+114
+115
+116
+117
+118
+119</div><code class="vscode-code">&lt;!DOCTYPE html&gt;
+&lt;<span class="sy-tag">html</span> <span class="sy-attr">lang</span>=<span class="sy-str">"ja"</span>&gt;
+&lt;<span class="sy-tag">head</span>&gt;
+  &lt;<span class="sy-tag">meta</span> <span class="sy-attr">charset</span>=<span class="sy-str">"UTF-8"</span>&gt;
+  &lt;<span class="sy-tag">meta</span> <span class="sy-attr">name</span>=<span class="sy-str">"viewport"</span> <span class="sy-attr">content</span>=<span class="sy-str">"width=device-width, initial-scale=1.0"</span>&gt;
+  &lt;<span class="sy-tag">title</span>&gt;SAMPLE SITE&lt;/<span class="sy-tag">title</span>&gt;
+  &lt;<span class="sy-tag">link</span> <span class="sy-attr">href</span>=<span class="sy-str">"css/style.css"</span> <span class="sy-attr">rel</span>=<span class="sy-str">"stylesheet"</span>&gt;
+&lt;/<span class="sy-tag">head</span>&gt;
+&lt;<span class="sy-tag">body</span>&gt;
+
+  &lt;<span class="sy-tag">div</span> <span class="sy-attr">class</span>=<span class="sy-str">"header"</span>&gt;
+    &lt;<span class="sy-tag">div</span> <span class="sy-attr">class</span>=<span class="sy-str">"header_contents"</span>&gt;
+      &lt;<span class="sy-tag">div</span> <span class="sy-attr">class</span>=<span class="sy-str">"logo"</span>&gt;
+        &lt;<span class="sy-tag">img</span> <span class="sy-attr">src</span>=<span class="sy-str">"images/logo_mark.webp"</span> <span class="sy-attr">alt</span>=<span class="sy-str">""</span> <span class="sy-attr">width</span>=<span class="sy-str">"40"</span> <span class="sy-attr">height</span>=<span class="sy-str">"40"</span>&gt;
+        SAMPLE SITE
+      &lt;/<span class="sy-tag">div</span>&gt;
+      <span class="sy-com">&lt;!-- ナビゲーション追加 --&gt;</span>
+      &lt;<span class="sy-tag">div</span> <span class="sy-attr">class</span>=<span class="sy-str">"nav"</span>&gt;
+        &lt;<span class="sy-tag">ul</span>&gt;
+          &lt;<span class="sy-tag">li</span>&gt;&lt;<span class="sy-tag">a</span> <span class="sy-attr">href</span>=<span class="sy-str">"#"</span>&gt;ホーム&lt;/<span class="sy-tag">a</span>&gt;&lt;/<span class="sy-tag">li</span>&gt;
+          &lt;<span class="sy-tag">li</span>&gt;&lt;<span class="sy-tag">a</span> <span class="sy-attr">href</span>=<span class="sy-str">"#"</span>&gt;レッスン&lt;/<span class="sy-tag">a</span>&gt;&lt;/<span class="sy-tag">li</span>&gt;
+          &lt;<span class="sy-tag">li</span>&gt;&lt;<span class="sy-tag">a</span> <span class="sy-attr">href</span>=<span class="sy-str">"#"</span>&gt;入門&lt;/<span class="sy-tag">a</span>&gt;&lt;/<span class="sy-tag">li</span>&gt;
+          &lt;<span class="sy-tag">li</span>&gt;&lt;<span class="sy-tag">a</span> <span class="sy-attr">href</span>=<span class="sy-str">"#"</span>&gt;基礎&lt;/<span class="sy-tag">a</span>&gt;&lt;/<span class="sy-tag">li</span>&gt;
+          &lt;<span class="sy-tag">li</span>&gt;&lt;<span class="sy-tag">a</span> <span class="sy-attr">href</span>=<span class="sy-str">"#"</span>&gt;応用&lt;/<span class="sy-tag">a</span>&gt;&lt;/<span class="sy-tag">li</span>&gt;
+          &lt;<span class="sy-tag">li</span>&gt;&lt;<span class="sy-tag">a</span> <span class="sy-attr">href</span>=<span class="sy-str">"#"</span>&gt;実践&lt;/<span class="sy-tag">a</span>&gt;&lt;/<span class="sy-tag">li</span>&gt;
+        &lt;/<span class="sy-tag">ul</span>&gt;
+      &lt;/<span class="sy-tag">div</span>&gt;
+      <span class="sy-com">&lt;!-- /ナビゲーション追加 --&gt;</span>
+    &lt;/<span class="sy-tag">div</span>&gt;
+  &lt;/<span class="sy-tag">div</span>&gt;
+
+  &lt;<span class="sy-tag">div</span> <span class="sy-attr">class</span>=<span class="sy-str">"contents"</span>&gt;
+    &lt;<span class="sy-tag">div</span> <span class="sy-attr">class</span>=<span class="sy-str">"visual"</span>&gt;
+      &lt;<span class="sy-tag">h1</span> <span class="sy-attr">class</span>=<span class="sy-str">"copy"</span>&gt;Webの基礎を、&lt;<span class="sy-tag">br</span>&gt;手を動かして学ぶ。&lt;/<span class="sy-tag">h1</span>&gt;
+    &lt;/<span class="sy-tag">div</span>&gt;
+
+    <span class="sy-com">&lt;!-- ここまでは前回のまま（テキストとメニュー） --&gt;</span>
+    &lt;<span class="sy-tag">div</span> <span class="sy-attr">class</span>=<span class="sy-str">"text_wrapper"</span>&gt;
+      &lt;<span class="sy-tag">div</span> <span class="sy-attr">class</span>=<span class="sy-str">"text"</span>&gt;
+        &lt;<span class="sy-tag">p</span>&gt;枠（ボックス）を組み立て、色や画像・テキストを入れて、
+           1つのWebサイトを完成させる流れを体験します。ブラウザ上の
+           あらゆる要素が「四角い枠」で構成されていることを学びましょう。&lt;/<span class="sy-tag">p</span>&gt;
+      &lt;/<span class="sy-tag">div</span>&gt;
+      &lt;<span class="sy-tag">div</span> <span class="sy-attr">class</span>=<span class="sy-str">"menu"</span>&gt;
+        &lt;<span class="sy-tag">ul</span>&gt;
+          &lt;<span class="sy-tag">li</span>&gt;ホーム&lt;/<span class="sy-tag">li</span>&gt;
+          &lt;<span class="sy-tag">li</span>&gt;レッスン&lt;/<span class="sy-tag">li</span>&gt;
+          &lt;<span class="sy-tag">li</span>&gt;入門&lt;/<span class="sy-tag">li</span>&gt;
+          &lt;<span class="sy-tag">li</span>&gt;基礎&lt;/<span class="sy-tag">li</span>&gt;
+          &lt;<span class="sy-tag">li</span>&gt;応用&lt;/<span class="sy-tag">li</span>&gt;
+        &lt;/<span class="sy-tag">ul</span>&gt;
+      &lt;/<span class="sy-tag">div</span>&gt;
+    &lt;/<span class="sy-tag">div</span>&gt;
+
+    <span class="sy-com">&lt;!-- コンテンツ追加 --&gt;</span>
+    &lt;<span class="sy-tag">div</span> <span class="sy-attr">class</span>=<span class="sy-str">"lessons"</span>&gt;
+      &lt;<span class="sy-tag">div</span> <span class="sy-attr">class</span>=<span class="sy-str">"card"</span>&gt;
+        &lt;<span class="sy-tag">img</span> <span class="sy-attr">src</span>=<span class="sy-str">"images/card_html.webp"</span> <span class="sy-attr">alt</span>=<span class="sy-str">"HTML &amp;amp; CSS"</span>&gt;
+        &lt;<span class="sy-tag">h3</span>&gt;HTML &amp;amp; CSS&lt;/<span class="sy-tag">h3</span>&gt;
+        &lt;<span class="sy-tag">p</span>&gt;Webページの構造と装飾。枠組みからレイアウトまでの基礎を学びます。&lt;/<span class="sy-tag">p</span>&gt;
+      &lt;/<span class="sy-tag">div</span>&gt;
+      &lt;<span class="sy-tag">div</span> <span class="sy-attr">class</span>=<span class="sy-str">"card"</span>&gt;
+        &lt;<span class="sy-tag">img</span> <span class="sy-attr">src</span>=<span class="sy-str">"images/card_js.webp"</span> <span class="sy-attr">alt</span>=<span class="sy-str">"JavaScript"</span>&gt;
+        &lt;<span class="sy-tag">h3</span>&gt;JavaScript&lt;/<span class="sy-tag">h3</span>&gt;
+        &lt;<span class="sy-tag">p</span>&gt;動きのあるページ作り。DOM操作やイベントの基本を身につけます。&lt;/<span class="sy-tag">p</span>&gt;
+      &lt;/<span class="sy-tag">div</span>&gt;
+      &lt;<span class="sy-tag">div</span> <span class="sy-attr">class</span>=<span class="sy-str">"card"</span>&gt;
+        &lt;<span class="sy-tag">img</span> <span class="sy-attr">src</span>=<span class="sy-str">"images/card_php.webp"</span> <span class="sy-attr">alt</span>=<span class="sy-str">"PHP"</span>&gt;
+        &lt;<span class="sy-tag">h3</span>&gt;PHP&lt;/<span class="sy-tag">h3</span>&gt;
+        &lt;<span class="sy-tag">p</span>&gt;サーバーサイドの入門。フォーム処理やDB連携の第一歩を学びます。&lt;/<span class="sy-tag">p</span>&gt;
+      &lt;/<span class="sy-tag">div</span>&gt;
+    &lt;/<span class="sy-tag">div</span>&gt;
+
+    &lt;<span class="sy-tag">div</span> <span class="sy-attr">class</span>=<span class="sy-str">"catchcopy"</span>&gt;
+      &lt;<span class="sy-tag">div</span> <span class="sy-attr">class</span>=<span class="sy-str">"readcopy"</span>&gt;
+        &lt;<span class="sy-tag">h2</span>&gt;Work&lt;/<span class="sy-tag">h2</span>&gt;
+      &lt;/<span class="sy-tag">div</span>&gt;
+      &lt;<span class="sy-tag">div</span> <span class="sy-attr">class</span>=<span class="sy-str">"bodycopy"</span>&gt;
+        &lt;<span class="sy-tag">p</span>&gt;手を動かして作る、から身につく。実際に手を動かして作った数だけ、
+           できることが増えていきます。&lt;/<span class="sy-tag">p</span>&gt;
+      &lt;/<span class="sy-tag">div</span>&gt;
+    &lt;/<span class="sy-tag">div</span>&gt;
+    <span class="sy-com">&lt;!-- /コンテンツ追加 --&gt;</span>
+  &lt;/<span class="sy-tag">div</span>&gt;
+
+  <span class="sy-com">&lt;!-- リンク集追加 --&gt;</span>
+  &lt;<span class="sy-tag">div</span> <span class="sy-attr">class</span>=<span class="sy-str">"footer"</span>&gt;
+    &lt;<span class="sy-tag">div</span> <span class="sy-attr">class</span>=<span class="sy-str">"footer_contents"</span>&gt;
+      &lt;<span class="sy-tag">div</span> <span class="sy-attr">class</span>=<span class="sy-str">"col"</span>&gt;
+        &lt;<span class="sy-tag">h4</span>&gt;SAMPLE SITE&lt;/<span class="sy-tag">h4</span>&gt;
+        &lt;<span class="sy-tag">ul</span>&gt;
+          &lt;<span class="sy-tag">li</span>&gt;&lt;<span class="sy-tag">a</span> <span class="sy-attr">href</span>=<span class="sy-str">"#"</span>&gt;会社概要&lt;/<span class="sy-tag">a</span>&gt;&lt;/<span class="sy-tag">li</span>&gt;
+          &lt;<span class="sy-tag">li</span>&gt;&lt;<span class="sy-tag">a</span> <span class="sy-attr">href</span>=<span class="sy-str">"#"</span>&gt;お問い合わせ&lt;/<span class="sy-tag">a</span>&gt;&lt;/<span class="sy-tag">li</span>&gt;
+          &lt;<span class="sy-tag">li</span>&gt;&lt;<span class="sy-tag">a</span> <span class="sy-attr">href</span>=<span class="sy-str">"#"</span>&gt;プライバシー&lt;/<span class="sy-tag">a</span>&gt;&lt;/<span class="sy-tag">li</span>&gt;
+        &lt;/<span class="sy-tag">ul</span>&gt;
+      &lt;/<span class="sy-tag">div</span>&gt;
+      &lt;<span class="sy-tag">div</span> <span class="sy-attr">class</span>=<span class="sy-str">"col"</span>&gt;
+        &lt;<span class="sy-tag">h4</span>&gt;コース&lt;/<span class="sy-tag">h4</span>&gt;
+        &lt;<span class="sy-tag">ul</span>&gt;
+          &lt;<span class="sy-tag">li</span>&gt;&lt;<span class="sy-tag">a</span> <span class="sy-attr">href</span>=<span class="sy-str">"#"</span>&gt;入門&lt;/<span class="sy-tag">a</span>&gt;&lt;/<span class="sy-tag">li</span>&gt;
+          &lt;<span class="sy-tag">li</span>&gt;&lt;<span class="sy-tag">a</span> <span class="sy-attr">href</span>=<span class="sy-str">"#"</span>&gt;基礎&lt;/<span class="sy-tag">a</span>&gt;&lt;/<span class="sy-tag">li</span>&gt;
+          &lt;<span class="sy-tag">li</span>&gt;&lt;<span class="sy-tag">a</span> <span class="sy-attr">href</span>=<span class="sy-str">"#"</span>&gt;応用&lt;/<span class="sy-tag">a</span>&gt;&lt;/<span class="sy-tag">li</span>&gt;
+        &lt;/<span class="sy-tag">ul</span>&gt;
+      &lt;/<span class="sy-tag">div</span>&gt;
+      &lt;<span class="sy-tag">div</span> <span class="sy-attr">class</span>=<span class="sy-str">"col"</span>&gt;
+        &lt;<span class="sy-tag">h4</span>&gt;リンク&lt;/<span class="sy-tag">h4</span>&gt;
+        &lt;<span class="sy-tag">ul</span>&gt;
+          &lt;<span class="sy-tag">li</span>&gt;&lt;<span class="sy-tag">a</span> <span class="sy-attr">href</span>=<span class="sy-str">"#"</span>&gt;ホーム&lt;/<span class="sy-tag">a</span>&gt;&lt;/<span class="sy-tag">li</span>&gt;
+          &lt;<span class="sy-tag">li</span>&gt;&lt;<span class="sy-tag">a</span> <span class="sy-attr">href</span>=<span class="sy-str">"#"</span>&gt;レッスン&lt;/<span class="sy-tag">a</span>&gt;&lt;/<span class="sy-tag">li</span>&gt;
+          &lt;<span class="sy-tag">li</span>&gt;&lt;<span class="sy-tag">a</span> <span class="sy-attr">href</span>=<span class="sy-str">"#"</span>&gt;実践&lt;/<span class="sy-tag">a</span>&gt;&lt;/<span class="sy-tag">li</span>&gt;
+        &lt;/<span class="sy-tag">ul</span>&gt;
+      &lt;/<span class="sy-tag">div</span>&gt;
+    &lt;/<span class="sy-tag">div</span>&gt;
+    &lt;<span class="sy-tag">div</span> <span class="sy-attr">class</span>=<span class="sy-str">"copyright"</span>&gt;© SAMPLE SITE&lt;/<span class="sy-tag">div</span>&gt;
+  &lt;/<span class="sy-tag">div</span>&gt;
+  <span class="sy-com">&lt;!-- /リンク集追加 --&gt;</span>
+
+&lt;/<span class="sy-tag">body</span>&gt;
+&lt;/<span class="sy-tag">html</span>&gt;</code></div></div>
+
+    <h3>css/style.css（全体）</h3>
+    <div class="vscode"><div class="vscode-titlebar"><span class="win-dot red"></span><span class="win-dot yellow"></span><span class="win-dot green"></span><span class="vscode-title">style.css — Visual Studio Code</span></div><div class="vscode-tabs"><div class="vscode-tab">index.html</div><div class="vscode-tab is-active">style.css</div></div><div class="vscode-body"><div class="vscode-gutter">1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+11
+12
+13
+14
+15
+16
+17
+18
+19
+20
+21
+22
+23
+24
+25
+26
+27
+28
+29
+30
+31
+32
+33
+34
+35
+36
+37
+38
+39
+40
+41
+42
+43
+44
+45
+46
+47
+48
+49
+50
+51
+52
+53
+54
+55
+56
+57
+58
+59
+60
+61
+62
+63
+64
+65
+66
+67
+68
+69
+70
+71
+72
+73
+74
+75
+76
+77
+78
+79
+80
+81
+82
+83
+84
+85
+86
+87
+88
+89
+90
+91
+92
+93
+94
+95
+96
+97
+98
+99
+100
+101
+102
+103
+104
+105
+106
+107
+108
+109
+110
+111
+112
+113
+114
+115
+116
+117
+118
+119
+120
+121
+122
+123
+124
+125
+126
+127
+128
+129
+130
+131
+132
+133
+134
+135
+136
+137
+138
+139
+140
+141
+142
+143
+144
+145
+146
+147
+148
+149
+150
+151
+152
+153
+154
+155
+156
+157
+158
+159
+160
+161
+162
+163
+164
+165
+166</div><code class="vscode-code"><span class="sy-sel">*</span> {
+  <span class="sy-attr">box-sizing</span>: border-box;
+  <span class="sy-attr">margin</span>: <span class="sy-num">0</span>;
+  <span class="sy-attr">padding</span>: <span class="sy-num">0</span>;
+}
+<span class="sy-sel">body</span> {
+  <span class="sy-attr">font-family</span>: "Helvetica Neue", Arial, "Hiragino Sans", Meiryo, sans-serif;
+  <span class="sy-attr">color</span>: <span class="sy-num">#333</span>;
+  <span class="sy-attr">background</span>: #fff;
+}
+<span class="sy-sel">a</span> {
+  <span class="sy-attr">color</span>: inherit;
+  <span class="sy-attr">text-decoration</span>: none;
+}
+<span class="sy-sel">ul</span> {
+  <span class="sy-attr">list-style</span>: none;
+}
+.header_contents,
+.contents,
+<span class="sy-sel">.footer_contents</span> {
+  <span class="sy-attr">width</span>: <span class="sy-num">980px</span>;
+  <span class="sy-attr">margin</span>: <span class="sy-num">0</span> auto;
+}
+
+<span class="sy-com">/* ヘッダー：全幅（下線が画面端まで）／中身は header_contents で中央寄せ、ロゴ＋ナビ */</span>
+<span class="sy-sel">.header</span> {
+  <span class="sy-attr">border-bottom</span>: <span class="sy-num">1px</span> solid #eee;
+}
+<span class="sy-sel">.header_contents</span> {
+  <span class="sy-attr">height</span>: <span class="sy-num">90px</span>;
+  <span class="sy-attr">display</span>: flex;
+  <span class="sy-attr">align-items</span>: center;
+  <span class="sy-attr">justify-content</span>: space-between;
+}
+<span class="sy-sel">.logo</span> {
+  <span class="sy-attr">display</span>: flex;
+  <span class="sy-attr">align-items</span>: center;
+  <span class="sy-attr">font-size</span>: <span class="sy-num">20px</span>;
+  <span class="sy-attr">font-weight</span>: bold;
+  <span class="sy-attr">letter-spacing</span>: <span class="sy-num">1px</span>;
+}
+<span class="sy-sel">.logo img</span> {
+  <span class="sy-attr">width</span>: <span class="sy-num">40px</span>;
+  <span class="sy-attr">height</span>: <span class="sy-num">40px</span>;
+  <span class="sy-attr">border-radius</span>: <span class="sy-num">8px</span>;
+  <span class="sy-attr">margin-right</span>: <span class="sy-num">12px</span>;
+}
+<span class="sy-sel">.nav ul</span> {
+  <span class="sy-attr">display</span>: flex;
+}
+<span class="sy-sel">.nav li</span> {
+  <span class="sy-attr">margin-left</span>: <span class="sy-num">24px</span>;
+  <span class="sy-attr">font-size</span>: <span class="sy-num">14px</span>;
+}
+<span class="sy-sel">.nav li:hover</span> {
+  <span class="sy-attr">color</span>: <span class="sy-num">#37b</span>;
+}
+
+<span class="sy-com">/* ビジュアル（ヒーロー） */</span>
+<span class="sy-sel">.visual</span> {
+  <span class="sy-attr">height</span>: <span class="sy-num">360px</span>;
+  <span class="sy-attr">margin-top</span>: <span class="sy-num">32px</span>;
+  <span class="sy-attr">margin-bottom</span>: <span class="sy-num">40px</span>;
+  <span class="sy-attr">background</span>: url("../images/top_bg.webp") no-repeat center center;
+  <span class="sy-attr">display</span>: flex;
+  <span class="sy-attr">align-items</span>: center;
+}
+<span class="sy-sel">.copy</span> {
+  <span class="sy-attr">color</span>: #fff;
+  <span class="sy-attr">padding-left</span>: <span class="sy-num">56px</span>;
+  <span class="sy-attr">font-size</span>: <span class="sy-num">38px</span>;
+  <span class="sy-attr">line-height</span>: <span class="sy-num">1.3</span>;
+}
+
+<span class="sy-com">/* 前回までのテキストとメニュー（そのまま残す） */</span>
+<span class="sy-sel">.text_wrapper</span> {
+  <span class="sy-attr">display</span>: flex;
+  <span class="sy-attr">justify-content</span>: center;
+  <span class="sy-attr">margin-bottom</span>: <span class="sy-num">44px</span>;
+}
+<span class="sy-sel">.text</span> {
+  <span class="sy-attr">width</span>: <span class="sy-num">560px</span>;
+  <span class="sy-attr">padding-right</span>: <span class="sy-num">40px</span>;
+  <span class="sy-attr">border-right</span>: <span class="sy-num">1px</span> solid #ddd;
+  <span class="sy-attr">line-height</span>: <span class="sy-num">1.9</span>;
+  <span class="sy-attr">color</span>: <span class="sy-num">#555</span>;
+}
+<span class="sy-sel">.menu</span> {
+  <span class="sy-attr">width</span>: <span class="sy-num">240px</span>;
+  <span class="sy-attr">padding-left</span>: <span class="sy-num">40px</span>;
+  <span class="sy-attr">line-height</span>: <span class="sy-num">1.9</span>;
+}
+
+<span class="sy-com">/* レッスンカード×3（flex） */</span>
+<span class="sy-sel">.lessons</span> {
+  <span class="sy-attr">display</span>: flex;
+  <span class="sy-attr">justify-content</span>: space-between;
+  <span class="sy-attr">margin-bottom</span>: <span class="sy-num">64px</span>;
+}
+<span class="sy-sel">.card</span> {
+  <span class="sy-attr">width</span>: <span class="sy-num">300px</span>;
+  <span class="sy-attr">border</span>: <span class="sy-num">1px</span> solid #eee;
+}
+<span class="sy-sel">.card img</span> {
+  <span class="sy-attr">width</span>: <span class="sy-num">100%</span>;
+  <span class="sy-attr">display</span>: block;
+}
+<span class="sy-sel">.card h3</span> {
+  <span class="sy-attr">font-size</span>: <span class="sy-num">18px</span>;
+  <span class="sy-attr">margin</span>: <span class="sy-num">18px</span> <span class="sy-num">18px</span> <span class="sy-num">8px</span>;
+}
+<span class="sy-sel">.card p</span> {
+  <span class="sy-attr">font-size</span>: <span class="sy-num">13px</span>;
+  <span class="sy-attr">color</span>: <span class="sy-num">#666</span>;
+  <span class="sy-attr">line-height</span>: <span class="sy-num">1.8</span>;
+  <span class="sy-attr">margin</span>: <span class="sy-num">0</span> <span class="sy-num">18px</span> <span class="sy-num">18px</span>;
+}
+
+<span class="sy-com">/* catchcopy：flex で幅を 1 : 3 の割合に分ける */</span>
+<span class="sy-sel">.catchcopy</span> {
+  <span class="sy-attr">display</span>: flex;
+  <span class="sy-attr">align-items</span>: center;
+  <span class="sy-attr">margin-bottom</span>: <span class="sy-num">64px</span>;
+}
+<span class="sy-sel">.readcopy</span> {
+  <span class="sy-attr">flex</span>: <span class="sy-num">1</span>;
+}
+<span class="sy-sel">.bodycopy</span> {
+  <span class="sy-attr">flex</span>: <span class="sy-num">3</span>;
+  <span class="sy-attr">padding-left</span>: <span class="sy-num">40px</span>;
+}
+<span class="sy-sel">.catchcopy h2</span> {
+  <span class="sy-attr">font-size</span>: <span class="sy-num">44px</span>;
+  <span class="sy-attr">letter-spacing</span>: <span class="sy-num">4px</span>;
+  <span class="sy-attr">color</span>: <span class="sy-num">#222</span>;
+}
+<span class="sy-sel">.catchcopy p</span> {
+  <span class="sy-attr">color</span>: <span class="sy-num">#666</span>;
+  <span class="sy-attr">line-height</span>: <span class="sy-num">1.9</span>;
+}
+
+<span class="sy-com">/* フッター（カラム） */</span>
+<span class="sy-sel">.footer</span> {
+  <span class="sy-attr">background</span>: <span class="sy-num">#222</span>;
+  <span class="sy-attr">color</span>: #bbb;
+  <span class="sy-attr">padding</span>: <span class="sy-num">40px</span> <span class="sy-num">0</span>;
+}
+<span class="sy-sel">.footer_contents</span> {
+  <span class="sy-attr">display</span>: flex;
+  <span class="sy-attr">justify-content</span>: space-around;
+}
+<span class="sy-sel">.col h4</span> {
+  <span class="sy-attr">color</span>: #fff;
+  <span class="sy-attr">font-size</span>: <span class="sy-num">14px</span>;
+  <span class="sy-attr">margin-bottom</span>: <span class="sy-num">12px</span>;
+}
+<span class="sy-sel">.col li</span> {
+  <span class="sy-attr">font-size</span>: <span class="sy-num">13px</span>;
+  <span class="sy-attr">padding</span>: <span class="sy-num">5px</span> <span class="sy-num">0</span>;
+}
+<span class="sy-sel">.copyright</span> {
+  <span class="sy-attr">text-align</span>: center;
+  <span class="sy-attr">font-size</span>: <span class="sy-num">12px</span>;
+  <span class="sy-attr">margin-top</span>: <span class="sy-num">28px</span>;
+  <span class="sy-attr">color</span>: <span class="sy-num">#777</span>;
+}</code></div></div>
+
+    <h3>完成イメージ</h3>
+    <p>
+      すべてを組み合わせると、次のような1ページになります。
+    </p>
+
+    <div class="chrome"><div class="chrome-tabbar"><span class="win-dot red"></span><span class="win-dot yellow"></span><span class="win-dot green"></span><div class="chrome-tab">SAMPLE SITE</div></div><div class="chrome-toolbar"><span class="chrome-nav">←&nbsp;→&nbsp;⟳</span><div class="chrome-url">file:///mysite/index.html</div></div><div class="chrome-viewport" style="padding: 0;">
+        <div class="browser-demo demo-reset dm4">
+
+        <!-- ナビゲーション追加 -->
+        <div class="header">
+          <div class="header_contents">
+            <div class="logo">
+              <img src="sample_site/images/logo_mark.webp" alt="" width="40" height="40">
+              SAMPLE SITE
+            </div>
+            <div class="nav">
+              <ul>
+                <li><a href="#">ホーム</a></li>
+                <li><a href="#">レッスン</a></li>
+                <li><a href="#">入門</a></li>
+                <li><a href="#">基礎</a></li>
+                <li><a href="#">応用</a></li>
+                <li><a href="#">実践</a></li>
+              </ul>
+            </div>
+            <!-- /ナビゲーション追加 -->
+          </div>
+        </div>
+
+        <div class="contents">
+          <div class="visual">
+            <h1 class="copy">Webの基礎を、<br>手を動かして学ぶ。</h1>
+          </div>
+
+          <!-- ここまでは前回のまま（テキストとメニュー） -->
+          <div class="text_wrapper">
+            <div class="text">
+              <p>枠（ボックス）を組み立て、色や画像・テキストを入れて、
+                 1つのWebサイトを完成させる流れを体験します。ブラウザ上の
+                 あらゆる要素が「四角い枠」で構成されていることを学びましょう。</p>
+            </div>
+            <div class="menu">
+              <ul>
+                <li>ホーム</li>
+                <li>レッスン</li>
+                <li>入門</li>
+                <li>基礎</li>
+                <li>応用</li>
+              </ul>
+            </div>
+          </div>
+
+          <!-- コンテンツ追加 -->
+          <div class="lessons">
+            <div class="card">
+              <img src="sample_site/images/card_html.webp" alt="HTML &amp; CSS">
+              <h3>HTML &amp; CSS</h3>
+              <p>Webページの構造と装飾。枠組みからレイアウトまでの基礎を学びます。</p>
+            </div>
+            <div class="card">
+              <img src="sample_site/images/card_js.webp" alt="JavaScript">
+              <h3>JavaScript</h3>
+              <p>動きのあるページ作り。DOM操作やイベントの基本を身につけます。</p>
+            </div>
+            <div class="card">
+              <img src="sample_site/images/card_php.webp" alt="PHP">
+              <h3>PHP</h3>
+              <p>サーバーサイドの入門。フォーム処理やDB連携の第一歩を学びます。</p>
+            </div>
+          </div>
+
+          <div class="catchcopy">
+            <div class="readcopy">
+              <h2>Work</h2>
+            </div>
+            <div class="bodycopy">
+              <p>手を動かして作る、から身につく。実際に手を動かして作った数だけ、
+                 できることが増えていきます。</p>
+            </div>
+          </div>
+          <!-- /コンテンツ追加 -->
+        </div>
+
+        <!-- リンク集追加 -->
+        <div class="footer">
+          <div class="footer_contents">
+            <div class="col">
+              <h4>SAMPLE SITE</h4>
+              <ul>
+                <li><a href="#">会社概要</a></li>
+                <li><a href="#">お問い合わせ</a></li>
+                <li><a href="#">プライバシー</a></li>
+              </ul>
+            </div>
+            <div class="col">
+              <h4>コース</h4>
+              <ul>
+                <li><a href="#">入門</a></li>
+                <li><a href="#">基礎</a></li>
+                <li><a href="#">応用</a></li>
+              </ul>
+            </div>
+            <div class="col">
+              <h4>リンク</h4>
+              <ul>
+                <li><a href="#">ホーム</a></li>
+                <li><a href="#">レッスン</a></li>
+                <li><a href="#">実践</a></li>
+              </ul>
+            </div>
+          </div>
+          <div class="copyright">© SAMPLE SITE</div>
+        </div>
+        <!-- /リンク集追加 -->
+
+        </div>
+      </div></div>
+
+    <div class="open-site-wrap">
+      <a class="open-site" href="sample_site/stage3_extended.html" target="_blank" rel="noopener">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h6"/></svg>
+        実際のサンプルサイトを開く（新しいタブ）
+      </a>
+    </div>
+
+    <h3>今回はじめて出てくる書き方</h3>
+    <p>
+      完成コードには、次の5つが新しく登場します。いずれも詳しい使い方は今後の研修で扱います。
+    </p>
+
+    <table>
+      <tr>
+        <th style="width: 32%;">書き方</th>
+        <th>意味</th>
+      </tr>
+      <tr>
+        <td><code>list-style: none</code></td>
+        <td>リストの先頭に標準で付く「●」を消す。ナビ・メニュー・リンク集の <code>&lt;ul&gt;</code> にまとめて指定する</td>
+      </tr>
+      <tr>
+        <td><code>color: inherit</code><br><code>text-decoration: none</code></td>
+        <td>リンクの<strong>青い文字＋下線</strong>を消し、まわりの文字になじませる（<code>inherit</code> ＝ 親の枠の文字色を受け継ぐ）</td>
+      </tr>
+      <tr>
+        <td><code>:hover</code></td>
+        <td><strong>疑似クラス</strong>。マウスを乗せたときだけ効く指定</td>
+      </tr>
+      <tr>
+        <td><code>flex: 1</code> / <code>flex: 3</code></td>
+        <td>横並びにした枠の幅を<strong>数値の比率</strong>で分ける（ここでは 1 : 3）</td>
+      </tr>
+      <tr>
+        <td><code>space-between</code><br><code>space-around</code></td>
+        <td>横並びの<strong>配置のしかた</strong>。<code>between</code> は両端いっぱいに寄せて間を均等に、<code>around</code> はそれぞれの左右に均等な余白（前ページの <code>center</code> は中央にまとめる）</td>
+      </tr>
+    </table>
+
+    <div class="point">
+      <span class="label">理解ポイント</span><br>
+      今回追加した部品は、どれも「<strong>枠を作って（div）、flex で並べる</strong>」の繰り返しです。ナビ・カード・フッターと、見た目は違っても仕組みは同じです。これまで学んだ基本の組み合わせだけで、本格的なレイアウトが作れることを確認しましょう。
+    </div>
+
+  </section>
+
+</main>
+
+<nav class="page-nav">
+  <a class="page-prev" href="beginner_3.html">
+    <span class="page-nav-label">前のページ</span>
+    <span class="page-nav-title">コーダー初級#3</span>
+    <span class="page-nav-sub">枠の中に画像・色・テキストを入れる</span>
+  </a>
+  <a class="page-next" href="beginner_5.html">
+    <span class="page-nav-label">次のページ</span>
+    <span class="page-nav-title">コーダー初級#5</span>
+    <span class="page-nav-sub">flex でレイアウトを組む</span>
+  </a>
+</nav>
+
+<footer>
+</footer>
+
+
+<script>
+  // ライブデモ（.browser-demo）を chrome 枠の幅にフィットさせる
+  (function () {
+    function fit() {
+      document.querySelectorAll('.browser-demo').forEach(function (d) {
+        d.style.zoom = d.parentElement.clientWidth / 1160;
+      });
+    }
+    window.addEventListener('load', fit);
+    window.addEventListener('resize', fit);
+  })();
+</script>
+
+<!-- ▼ 共通スクリプト。章ナビ・コピーボタン・先頭へ戻るが自動で付く（編集不要） -->
+<script src="../js/training.js"></script>
+</body>
+</html>

--- a/docs/training/css/beginner_4.css
+++ b/docs/training/css/beginner_4.css
@@ -1,0 +1,286 @@
+/* ============================================================
+   コーダー初級#4（beginner_4.html）専用のスタイル
+
+   全ページ共通の土台は training.css にあります。
+   ここに置くのは、このページだけで使う図やデモのスタイルです。
+   ============================================================ */
+
+/* ── 素材のダウンロードボタン ── */
+.dl-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: #2563eb;
+  color: #fff;
+  font-weight: 700;
+  font-size: 15px;
+  line-height: 1;
+  padding: 11px 18px;
+  border-radius: 8px;
+  text-decoration: none;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+.dl-btn:hover {
+  background: #1d4ed8;
+  text-decoration: none;
+}
+.dl-btn svg {
+  width: 18px;
+  height: 18px;
+  display: block;
+}
+.dl-note {
+  margin-left: 10px;
+  font-size: 14px;
+  color: #64748b;
+}
+
+/* ── サンプルサイトを開くリンク（アウトラインボタン） ── */
+.open-site-wrap {
+  text-align: center;
+  margin: 14px 0 4px;
+}
+.open-site {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 9px 16px;
+  border: 1.5px solid #2563eb;
+  border-radius: 8px;
+  color: #2563eb;
+  font-weight: 700;
+  font-size: 14px;
+  text-decoration: none;
+  background: #fff;
+}
+.open-site:hover {
+  background: #eff6ff;
+  text-decoration: none;
+}
+.open-site svg {
+  width: 16px;
+  height: 16px;
+}
+
+/* ── ライブデモの表示枠 ──
+   実寸（幅1160pxのウィンドウ相当）で組み、zoom で枠内に縮小表示する。
+   zoom の値はページ末尾のフィットスクリプトが上書きする。 */
+.browser-demo {
+  width: 1160px;
+  zoom: 0.72;
+  background: #fff;
+  padding: 8px;  /* ブラウザ既定の body 余白（8px）の再現 */
+}
+.browser-demo * {
+  box-sizing: content-box;
+}
+
+/* リセット前のブラウザ既定に合わせる */
+.browser-demo.demo-reset {
+  padding: 0;
+}
+
+/* * { margin: 0 } リセット済みのページ用 */
+.browser-demo.demo-reset * {
+  box-sizing: border-box;
+}
+
+/* デモ内は教材ページ側の見出し・段落装飾を打ち消してブラウザ既定に戻す */
+.browser-demo :is(h1,
+h2,
+h3,
+h4,
+h5,
+h6) {
+  margin: revert;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: inherit;
+  letter-spacing: normal;
+  font-size: revert;
+  font-weight: revert;
+  line-height: revert;
+}
+.browser-demo p {
+  margin: revert;
+}
+.browser-demo.demo-reset :is(h1,
+h2,
+h3,
+h4,
+h5,
+h6),
+.browser-demo.demo-reset p {
+  margin: 0;
+}
+
+/* ── ライブデモ用：完成CSS（css/style.css）を .dm4 スコープで再現 ──
+   教材のコードを変更したら、ここも合わせて更新すること */
+.dm4 * {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+.dm4 {
+  font-family: "Helvetica Neue", Arial, "Hiragino Sans", Meiryo, sans-serif;
+  color: #333;
+  background: #fff;
+}
+.dm4 a {
+  color: inherit;
+  text-decoration: none;
+}
+.dm4 ul {
+  list-style: none;
+}
+.dm4 .header_contents,
+.dm4 .contents,
+.dm4 .footer_contents {
+  width: 980px;
+  margin: 0 auto;
+}
+
+/* ヘッダー：全幅（下線が画面端まで）／中身は header_contents で中央寄せ、ロゴ＋ナビ */
+.dm4 .header {
+  border-bottom: 1px solid #eee;
+}
+.dm4 .header_contents {
+  height: 90px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.dm4 .logo {
+  display: flex;
+  align-items: center;
+  font-size: 20px;
+  font-weight: bold;
+  letter-spacing: 1px;
+}
+.dm4 .logo img {
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+  margin-right: 12px;
+}
+.dm4 .nav ul {
+  display: flex;
+}
+.dm4 .nav li {
+  margin-left: 24px;
+  font-size: 14px;
+}
+.dm4 .nav li:hover {
+  color: #37b;
+}
+
+/* ビジュアル（ヒーロー） */
+.dm4 .visual {
+  height: 360px;
+  margin-top: 32px;
+  margin-bottom: 40px;
+  background: url("../cbc_internal/sample_site/images/top_bg.webp") no-repeat center center;
+  display: flex;
+  align-items: center;
+}
+.dm4 .copy {
+  color: #fff;
+  padding-left: 56px;
+  font-size: 38px;
+  line-height: 1.3;
+}
+
+/* 前回までのテキストとメニュー（そのまま残す） */
+.dm4 .text_wrapper {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 44px;
+}
+.dm4 .text {
+  width: 560px;
+  padding-right: 40px;
+  border-right: 1px solid #ddd;
+  line-height: 1.9;
+  color: #555;
+}
+.dm4 .menu {
+  width: 240px;
+  padding-left: 40px;
+  line-height: 1.9;
+}
+
+/* レッスンカード×3（flex） */
+.dm4 .lessons {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 64px;
+}
+.dm4 .card {
+  width: 300px;
+  border: 1px solid #eee;
+}
+.dm4 .card img {
+  width: 100%;
+  display: block;
+}
+.dm4 .card h3 {
+  font-size: 18px;
+  margin: 18px 18px 8px;
+}
+.dm4 .card p {
+  font-size: 13px;
+  color: #666;
+  line-height: 1.8;
+  margin: 0 18px 18px;
+}
+
+/* catchcopy：flex で幅を 1 : 3 の割合に分ける */
+.dm4 .catchcopy {
+  display: flex;
+  align-items: center;
+  margin-bottom: 64px;
+}
+.dm4 .readcopy {
+  flex: 1;
+}
+.dm4 .bodycopy {
+  flex: 3;
+  padding-left: 40px;
+}
+.dm4 .catchcopy h2 {
+  font-size: 44px;
+  letter-spacing: 4px;
+  color: #222;
+}
+.dm4 .catchcopy p {
+  color: #666;
+  line-height: 1.9;
+}
+
+/* フッター（カラム） */
+.dm4 .footer {
+  background: #222;
+  color: #bbb;
+  padding: 40px 0;
+}
+.dm4 .footer_contents {
+  display: flex;
+  justify-content: space-around;
+}
+.dm4 .col h4 {
+  color: #fff;
+  font-size: 14px;
+  margin-bottom: 12px;
+}
+.dm4 .col li {
+  font-size: 13px;
+  padding: 5px 0;
+}
+.dm4 .copyright {
+  text-align: center;
+  font-size: 12px;
+  margin-top: 28px;
+  color: #777;
+}
+


### PR DESCRIPTION
## 概要

コーダー初級#4 の教材ページを追加しました。
3セクション構成です（21〜23章）。

21. 完成したレイアウトを拡張する（ナビ・レッスンカード・フッター）
22. 素材画像を準備する
23. 完成コードと表示イメージ

- 見本は画像ではなくライブデモ
- 「今回はじめて出てくる書き方」を表で掲載
  list-style / color: inherit / text-decoration / :hover / flex の比率指定 /
  space-between と space-around の5項目です。
  完成コードにまとめて登場するため、コードを読む前に一覧で押さえられるようにしています。
  詳しい使い方は今後の研修で扱う旨も添えています。

## ファイル

新規追加のみで、既存ファイルの変更はありません。

- docs/training/cbc_internal/beginner_4.html
- docs/training/css/beginner_4.css

## 補足

見本サイトと素材（sample_site/）は #2 のPRに含めています。
そのためベースを #2 のブランチにしています。#2 のマージ後に付け替えます。

完成コードは sample_site/stage3_extended.html と css/stage3.css として作成しています。
