### PR TITLE
コーダー編 全ページにサブタイトルを追加し、前後ページのリンクと表記を修正

### DIFF
--- a/docs/training/cbc_internal/beginner_1.html
+++ b/docs/training/cbc_internal/beginner_1.html
@@ -19,6 +19,7 @@
 <header>
   <div class="header-inner">
     <h1>コーダー初級#1</h1>
+    <p>準備からHTML・CSSの基本まで</p>
   </div>
 </header>
 
@@ -1605,7 +1606,7 @@
   <a class="page-next" href="beginner_2.html">
     <span class="page-nav-label">次のページ</span>
     <span class="page-nav-title">コーダー初級#2</span>
-    <span class="page-nav-sub">レスポンシブコーディングとは</span>
+    <span class="page-nav-sub">枠を組み立ててレイアウトを作る</span>
   </a>
 </nav>
 

--- a/docs/training/cbc_internal/beginner_2.html
+++ b/docs/training/cbc_internal/beginner_2.html
@@ -20,6 +20,7 @@
 <header>
   <div class="header-inner">
     <h1>コーダー初級#2</h1>
+    <p>枠を組み立ててレイアウトを作る</p>
   </div>
 </header>
 

--- a/docs/training/cbc_internal/beginner_3.html
+++ b/docs/training/cbc_internal/beginner_3.html
@@ -22,6 +22,7 @@
 <header>
   <div class="header-inner">
     <h1>コーダー初級#3</h1>
+    <p>枠の中に画像・色・テキストを入れる</p>
   </div>
 </header>
 

--- a/docs/training/cbc_internal/beginner_4.html
+++ b/docs/training/cbc_internal/beginner_4.html
@@ -19,6 +19,7 @@
 <header>
   <div class="header-inner">
     <h1>コーダー初級#4</h1>
+    <p>レイアウトを拡張する</p>
   </div>
 </header>
 
@@ -844,8 +845,8 @@
   </a>
   <a class="page-next" href="beginner_5.html">
     <span class="page-nav-label">次のページ</span>
-    <span class="page-nav-title">コーダー初級#5</span>
-    <span class="page-nav-sub">flex でレイアウトを組む</span>
+    <span class="page-nav-title">コーダー中級#5</span>
+    <span class="page-nav-sub">要素を並べる ― flexbox と grid</span>
   </a>
 </nav>
 

--- a/docs/training/cbc_internal/beginner_5.html
+++ b/docs/training/cbc_internal/beginner_5.html
@@ -2201,7 +2201,7 @@ column-gap: 4px;</code>
   <a class="page-prev" href="beginner_4.html">
     <span class="page-nav-label">前のページ</span>
     <span class="page-nav-title">コーダー初級#4</span>
-    <span class="page-nav-sub">エクセル関数について</span>
+    <span class="page-nav-sub">レイアウトを拡張する</span>
   </a>
   <a class="page-next" href="beginner_6.html">
     <span class="page-nav-label">次のページ</span>

--- a/docs/training/cbc_internal/beginner_6.html
+++ b/docs/training/cbc_internal/beginner_6.html
@@ -796,7 +796,7 @@
   <a class="page-next" href="beginner_7.html">
     <span class="page-nav-label">次のページ</span>
     <span class="page-nav-title">コーダー中級#7</span>
-    <span class="page-nav-sub">昔ながらの横並びと、要素の狙い方</span>
+    <span class="page-nav-sub">昔ながらの横並びと、要素の狙い方 ― float と セレクタ</span>
   </a>
 </nav>
 

--- a/docs/training/cbc_internal/beginner_7.html
+++ b/docs/training/cbc_internal/beginner_7.html
@@ -807,10 +807,10 @@
     <span class="page-nav-title">コーダー中級#6</span>
     <span class="page-nav-sub">要素の性質と位置 ― display と position</span>
   </a>
-  <a class="page-next" href="basic_1.html">
+  <a class="page-next" href="beginner_8.html">
     <span class="page-nav-label">次のページ</span>
-    <span class="page-nav-title">マークアップ初級#1</span>
-    <span class="page-nav-sub">インターネットの仕組みを理解しよう</span>
+    <span class="page-nav-title">コーダー上級#1</span>
+    <span class="page-nav-sub">1ページをまるごと作る ― 実践コーディング</span>
   </a>
 </nav>
 

--- a/docs/training/cbc_internal/beginner_8.html
+++ b/docs/training/cbc_internal/beginner_8.html
@@ -13,6 +13,7 @@
 <header>
   <div class="header-inner">
     <h1>コーダー上級#1</h1>
+    <p>1ページをまるごと作る ― 実践コーディング</p>
   </div>
 </header>
 
@@ -2511,13 +2512,13 @@
 <nav class="page-nav">
   <a class="page-prev" href="beginner_7.html">
     <span class="page-nav-label">前のページ</span>
-    <span class="page-nav-title">コーダー中級#3</span>
-    <span class="page-nav-sub">レイアウトの組み立てを深める</span>
+    <span class="page-nav-title">コーダー中級#7</span>
+    <span class="page-nav-sub">昔ながらの横並びと、要素の狙い方 ― float と セレクタ</span>
   </a>
   <a class="page-next" href="basic_1.html">
     <span class="page-nav-label">次のページ</span>
-    <span class="page-nav-title">マークアップ中級#1</span>
-    <span class="page-nav-sub">マークアップの実務を学ぶ</span>
+    <span class="page-nav-title">マークアップ初級#1</span>
+    <span class="page-nav-sub">インターネットの仕組みを理解しよう</span>
   </a>
 </nav>
 


### PR DESCRIPTION
## 概要

公開後のページを通しで確認したところ、ページ間のつながりに食い違いが見つかったため修正しました。あわせて、サブタイトルの有無がページごとにばらついていたので揃えています。

改行コードは各ファイルの元の状態を維持しました（リポジトリ内で CRLF / LF が混在しているため）。