### PR TITLE
マークアップ編のページ間リンクと級表記を修正

### DIFF
--- a/docs/training/cbc_internal/basic_1.html
+++ b/docs/training/cbc_internal/basic_1.html
@@ -748,10 +748,10 @@
 </main>
 
 <nav class="page-nav">
-  <a class="page-prev" href="beginner_7.html">
+  <a class="page-prev" href="beginner_8.html">
     <span class="page-nav-label">前のページ</span>
-    <span class="page-nav-title">コーダー中級#7</span>
-    <span class="page-nav-sub">昔ながらの横並びと、要素の狙い方</span>
+    <span class="page-nav-title">コーダー上級#1</span>
+    <span class="page-nav-sub">1ページをまるごと作る ― 実践コーディング</span>
   </a>
   <a class="page-next" href="basic_2.html">
     <span class="page-nav-label">次のページ</span>

--- a/docs/training/cbc_internal/basic_3.html
+++ b/docs/training/cbc_internal/basic_3.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>マークアップ中級#3</title>
+  <title>マークアップ初級#3</title>
   <link rel="stylesheet" href="../css/training.css">
 
   <!-- ▼ このページ専用のスタイル（制作手順の実演） -->
@@ -18,7 +18,7 @@
 
 <header>
   <div class="header-inner">
-    <h1>マークアップ中級#3</h1>
+    <h1>マークアップ初級#3</h1>
     <p>レスポンシブサイトをコーディングする方法</p>
   </div>
 </header>
@@ -601,7 +601,7 @@ no-repeat           … 繰り返さない</span></code>
       <span class="label">やっていることは3つだけ</span><br>
       レスポンシブ対応の中身は、ほとんどがこの3つです。<br>
       <strong>1. 固定幅（1200px）を <code>100%</code> にする</strong>／<strong>2. 横並び（flex）を縦積み（column）にする</strong>／<strong>3. 列の数を減らす（4列→2列）</strong>。<br>
-      新しい技術ではなく、<a href="basic_2.html#chapter2">中級#2</a> でやったメディアクエリの使い分けです。
+      新しい技術ではなく、<a href="basic_2.html#chapter2">初級#2</a> でやったメディアクエリの使い分けです。
     </div>
 
     <h3>幅を切り替えて確かめる</h3>
@@ -938,7 +938,7 @@ no-repeat           … 繰り返さない</span></code>
 <nav class="page-nav">
   <a class="page-prev" href="basic_2.html">
     <span class="page-nav-label">前のページ</span>
-    <span class="page-nav-title">マークアップ中級#2</span>
+    <span class="page-nav-title">マークアップ初級#2</span>
     <span class="page-nav-sub">初めてのレスポンシブコーディング</span>
   </a>
   <a class="page-next" href="basic_4.html">

--- a/docs/training/cbc_internal/basic_4.html
+++ b/docs/training/cbc_internal/basic_4.html
@@ -459,7 +459,7 @@
     <div class="point">
       <span class="label">エラーは敵ではない</span><br>
       エラーは<strong>「ここがおかしい」と教えてくれている</strong>だけです。無視して消すのではなく、<strong>何を言っているのかを読む</strong>。<br>
-      <a href="basic_7.html#chapter3">中級#7</a> でやるブラウザのエラーも同じです。<strong>読む習慣がある人だけが、早く直せます。</strong>
+      この先、ブラウザでプログラムを書くようになっても同じです（<a href="basic_7.html">中級#7</a>）。<strong>読む習慣がある人だけが、早く直せます。</strong>
     </div>
 
     <h3>IS系関数で先に防ぐ</h3>
@@ -527,7 +527,7 @@
     <div class="point">
       <span class="label">これがヒューマンエラー対策</span><br>
       <strong>「同じ情報を2箇所に書かない」</strong>。表の数字と文章の数字が別々にあると、必ずどこかで食い違います。<br>
-      式でつないでおけば、<strong>表を直せば文章も自動で直ります</strong>。<a href="basic_3.html#chapter6">中級#3</a> でCSSの重複を避けたのと、まったく同じ考え方です。
+      式でつないでおけば、<strong>表を直せば文章も自動で直ります</strong>。<a href="basic_3.html#chapter6">初級#3</a> でCSSの重複を避けたのと、まったく同じ考え方です。
     </div>
 
     <h3>書き方</h3>
@@ -752,7 +752,7 @@
 <nav class="page-nav">
   <a class="page-prev" href="basic_3.html">
     <span class="page-nav-label">前のページ</span>
-    <span class="page-nav-title">マークアップ中級#3</span>
+    <span class="page-nav-title">マークアップ初級#3</span>
     <span class="page-nav-sub">レスポンシブサイトをコーディングする方法</span>
   </a>
   <a class="page-next" href="basic_5.html">

--- a/docs/training/cbc_internal/basic_7.html
+++ b/docs/training/cbc_internal/basic_7.html
@@ -1174,6 +1174,10 @@ $(<span class="v">'.modal-close'</span>).on(<span class="v">'click'</span>, <spa
     <span class="page-nav-title">マークアップ中級#6</span>
     <span class="page-nav-sub">JavaScriptを短く書く道具 ― jQueryの基本</span>
   </a>
+  <a class="page-next" href="advanced_1.html">
+    <span class="page-nav-label">次のページ</span>
+    <span class="page-nav-title">フロントエンド初級#1</span>
+  </a>
 </nav>
 
 <footer></footer>


### PR DESCRIPTION
マークアップ編のページ間リンクと級表記を修正します。

## 修正内容

- basic_1: 「前のページ」がコーダー上級#1を飛ばしてコーダー中級#7を指していたため修正
- basic_7: マークアップ編の最終ページから次への導線がなかったため、フロントエンド初級#1へのリンクを追加
- basic_3: basic_2 への参照が「中級#2」となっていたのを「初級#2」に修正
- basic_4: basic_3 への参照が「中級#3」となっていたのを「初級#3」に修正

級の区分（#1〜#3 初級 / #4〜#7 中級）は変更していません。

## 確認したこと

- コーダー初級#1 から フロントエンド初級#1 まで、全ページの前後リンクが鎖としてつながること
- page-nav のタイトルがリンク先ページの実体と一致すること
- マークアップ編の本文参照38件がすべて実体と一致すること
- 切れアンカーなし、タグ整合、重複IDなし、改行コードは各ファイルの元の形式を維持