### PR TITLE
コーダー修正: 課題の案内を追加等

### DIFF
--- a/docs/training/cbc_internal/beginner_7.html
+++ b/docs/training/cbc_internal/beginner_7.html
@@ -809,7 +809,7 @@
   </a>
   <a class="page-next" href="beginner_8.html">
     <span class="page-nav-label">次のページ</span>
-    <span class="page-nav-title">コーダー上級#1</span>
+    <span class="page-nav-title">コーダー上級#8</span>
     <span class="page-nav-sub">1ページをまるごと作る ― 実践コーディング</span>
   </a>
 </nav>

--- a/docs/training/cbc_internal/beginner_8.html
+++ b/docs/training/cbc_internal/beginner_8.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>コーダー上級#1</title>
+  <title>コーダー上級#8</title>
   <link rel="stylesheet" href="../css/training.css">
   <link rel="stylesheet" href="../css/beginner_8.css">
   <script src="../js/scroll-reset.js"></script>
@@ -12,7 +12,7 @@
 
 <header>
   <div class="header-inner">
-    <h1>コーダー上級#1</h1>
+    <h1>コーダー上級#8</h1>
     <p>1ページをまるごと作る ― 実践コーディング</p>
   </div>
 </header>
@@ -32,6 +32,7 @@
       <li><a href="#step7">news エリア</a></li>
       <li><a href="#step8">枠が完成</a></li>
       <li><a href="#step9">画像や文字要素を入れ込んでいく</a></li>
+      <li><a href="#step10">課題について</a></li>
     </ol>
   </section>
 
@@ -2505,6 +2506,24 @@
       <code>0</code> で透明、<code>1</code> で完全な黒になります。
     </p>
 
+    <h3 id="step10">10. 課題について</h3>
+    <p>
+      ここまでで、コーダー編の学習は終わりです。
+      次のマークアップ編に進む前に、<strong>コーダー編の課題を提出</strong>してください。
+    </p>
+
+    <div class="exercise">
+      <span class="label">課題</span><br>
+      課題の内容は <a href="../cbc/beginner/index.html">コーダー編の案内ページ</a> の「課題」に書かれています。<br>
+      提出は GitHub で行います。手順は <a href="https://github.com/epkotsoftware/training-docs/blob/main/submission/README.md#研修課題提出">研修課題提出</a> を参照してください。
+    </div>
+
+    <div class="caution">
+      <span class="label">提出したら</span><br>
+      提出した日付で「<a href="https://github.com/epkotsoftware/training-docs/blob/main/training/progress/README.md">研修進捗</a>」資料を更新してください。<br>
+      そのあと <a href="basic_1.html">マークアップ初級#1</a> に進みます。
+    </div>
+
   </section>
 
 </main>
@@ -2514,11 +2533,6 @@
     <span class="page-nav-label">前のページ</span>
     <span class="page-nav-title">コーダー中級#7</span>
     <span class="page-nav-sub">昔ながらの横並びと、要素の狙い方 ― float と セレクタ</span>
-  </a>
-  <a class="page-next" href="basic_1.html">
-    <span class="page-nav-label">次のページ</span>
-    <span class="page-nav-title">マークアップ初級#1</span>
-    <span class="page-nav-sub">インターネットの仕組みを理解しよう</span>
   </a>
 </nav>
 


### PR DESCRIPTION
## 概要

- 末尾に「10. 課題について」を追加。課題内容は原典 cbc/beginner/index.md へ、提出手順は training-docs の研修課題提出へリンクし、提出後にマークアップ初級へ進むよう案内
- 下部ナビの次ページ（basic_1.html）を削除し、前ページのみ残す
- 号数を通し番号の「コーダー上級 8」に変更

## ファイル

- docs/training/cbc_internal/beginner_8.html — 課題案内の追加、次ページリンクの削除、号数変更
- docs/training/cbc_internal/beginner_7.html — 次ページリンクの表記を号数変更に合わせて修正

## 補足

- 通し番号が未反映であったため、あわせて修正しています