### PR TITLE
マークアップ編: 編をまたぐページ送りを削除し、課題提出の案内を追加

### DIFF
--- a/docs/training/cbc_internal/basic_1.html
+++ b/docs/training/cbc_internal/basic_1.html
@@ -748,11 +748,6 @@
 </main>
 
 <nav class="page-nav">
-  <a class="page-prev" href="beginner_8.html">
-    <span class="page-nav-label">前のページ</span>
-    <span class="page-nav-title">コーダー上級#1</span>
-    <span class="page-nav-sub">1ページをまるごと作る ― 実践コーディング</span>
-  </a>
   <a class="page-next" href="basic_2.html">
     <span class="page-nav-label">次のページ</span>
     <span class="page-nav-title">マークアップ初級#2</span>

--- a/docs/training/cbc_internal/basic_7.html
+++ b/docs/training/cbc_internal/basic_7.html
@@ -1164,6 +1164,11 @@ $(<span class="v">'.modal-close'</span>).on(<span class="v">'click'</span>, <spa
 });</code>
       </details>
     </div>
+
+    <div class="caution">
+      <span class="label">マークアップ編の課題提出があります</span><br>
+      提出後、次へ進んでください。
+    </div>
   </section>
 
 </main>
@@ -1173,10 +1178,6 @@ $(<span class="v">'.modal-close'</span>).on(<span class="v">'click'</span>, <spa
     <span class="page-nav-label">前のページ</span>
     <span class="page-nav-title">マークアップ中級#6</span>
     <span class="page-nav-sub">JavaScriptを短く書く道具 ― jQueryの基本</span>
-  </a>
-  <a class="page-next" href="advanced_1.html">
-    <span class="page-nav-label">次のページ</span>
-    <span class="page-nav-title">フロントエンド初級#1</span>
   </a>
 </nav>
 


### PR DESCRIPTION
## 概要

課題を提出せずに次の編へ進んでしまうケースがあるため、編をまたぐページ送りリンクを削除しました。あわせて、編の最後に課題提出の案内を追加しています。

## 変更内容

### basic_1.html
- 前ページリンク（コーダー上級#1）を削除

### basic_7.html
- 次ページリンク（フロントエンド初級#1）を削除
- 本文の最後に課題提出の案内を追加

## 補足

マークアップ編の中（#1〜#7）のページ送りは従来どおりです。削除したのは編をまたぐ2箇所だけです。

同じ対応をフロントエンド編・バックエンド編にも入れています。