### PR TITLE
フロントエンド編: 課題提出の案内を追加

### DIFF
--- a/docs/training/cbc_internal/advanced_class2.html
+++ b/docs/training/cbc_internal/advanced_class2.html
@@ -764,6 +764,11 @@ if (isset($_POST['id'])) {
       実務でも同じことをします。<strong>まず動かして、あとから形を整える。</strong>最初から完璧に書ける人はいません。<br>
       <strong>「動くものを、より良い形にできる」。</strong>これが身についていれば、どの言語でも通用します。
     </div>
+
+    <div class="caution">
+      <span class="label">フロントエンド編の課題提出があります</span><br>
+      提出後、次へ進んでください。
+    </div>
   </section>
 
 


### PR DESCRIPTION
## 概要

課題を提出せずに次の編へ進んでしまうケースがあるため、編の最後に課題提出の案内を追加しました。

## 変更内容

### advanced_class2.html
- 本文の最後に課題提出の案内を追加

## 補足

フロントエンド編は最終ページに次ページリンクが無いため、リンクの削除はありません。

同じ対応をマークアップ編・バックエンド編にも入れています。