### PR TITLE
フロントエンド編#5〜#9: 説明の矛盾・旧番号・死にリンクを修正

### DIFF
--- a/docs/training/cbc_internal/advanced_5.html
+++ b/docs/training/cbc_internal/advanced_5.html
@@ -54,7 +54,7 @@
     <div class="exercise">
       <span class="label">課題</span><br>
       このページで作るのは <code>03_advanced/htdocs/index.php</code> です。<br>
-      章の途中に<strong>演習が3つ</strong>あります（この色の枠です）。出てきたその場で書いてください。<br>
+      章の途中に<strong>演習が4つ</strong>あります（この色の枠です）。出てきたその場で書いてください。<br>
       完成は <a href="advanced_7.html">フロントエンド中級#7</a> までかかります。
     </div>
 
@@ -478,10 +478,10 @@
       <strong>開発中だけ出す。</strong>実際のサービスでは、画面には出さずログに残します。
     </div>
 
-    <h3>PDO のエラーも出るようにする</h3>
+    <h3>PDO のエラー処理を明示する</h3>
 
     <p>
-      上の2行は「PHPのエラー」を出す設定です。<strong>PDO には、別にもう1つ指定が要ります。</strong>
+      上の2行は「PHPのエラー」を出す設定です。<strong>PDO では、SQLに失敗したときの動作を指定できます。</strong>PHP 8以降は例外を出す動作が既定ですが、この教材では設定を明示します。
     </p>
 
     <div class="vscode">
@@ -513,7 +513,7 @@
       </tr>
       <tr>
         <td><code>ERRMODE_EXCEPTION</code></td>
-        <td>SQLに失敗したとき、<strong>その場で止まってエラーを出す</strong>。指定しないと、失敗しても黙って進みます</td>
+        <td>SQLに失敗したとき、<strong>例外を出す</strong>。PHP 8以降は既定の動作です。PHP 7以前では、この動作にするために指定が必要です</td>
       </tr>
       <tr>
         <td><code>FETCH_ASSOC</code></td>
@@ -538,7 +538,8 @@
       <span class="label">演習2</span><br>
       <code>03_advanced/htdocs/index.php</code> を作り、<strong>DBに接続するところまで</strong>書いてください。<br>
       接続できたか確かめるため、最後に <code>echo '接続成功';</code> を入れて、ブラウザで開いてみましょう。<br>
-      <strong>わざと失敗させてみるのも大事です。</strong><code>dbname</code> を存在しない名前に変えて、どんなエラーが出るか見てください。
+      <strong>わざと失敗させてみるのも大事です。</strong><code>dbname</code> を存在しない名前に変えて、どんなエラーが出るか見てください。<br>
+      接続確認が終わったら、確認用の <code>echo '接続成功';</code> を削除してから次の章へ進んでください。
       <span class="ad-label">index.php（穴埋め）</span>
       <code class="ad-code hl"><span class="sy-tag">&lt;?php</span>
 <span class="ad-f">ini_set</span>(<span class="ad-s">'display_errors'</span>, <span class="ad-s">'1'</span>);
@@ -652,13 +653,14 @@
     <div class="note">
       <span class="label">型が付いて返ってくる</span><br>
       <code>int(810)</code> <code>string(6)</code> のように、<strong>カラムの型がそのまま反映されます。</strong>数値のカラムは数値、文字のカラムは文字です。<br>
-      ただし<strong>これはDBから読んだときの話</strong>です。<a href="advanced_6.html">次のページ</a>で扱う<strong>フォームから送られてきた値は、数字を入力しても文字</strong>になります。<a href="basic_7.html#chapter3">マークアップ中級#7</a> でやった <code>'10' + 5</code> の問題は、そちらで起きます。
+      ただしこれはDBから読んだときの話です。次のページで扱うフォームから送られてきた値は、数字を入力しても文字になります。<strong>文字列と数値の計算方法はJavaScriptとPHPで違う</strong>ので、次のページで確認します。
     </div>
 
     <div class="exercise">
       <span class="label">演習3</span><br>
       <code>sortable</code> テーブルの中身を取り出して、<code>var_dump()</code> で表示してください。<br>
-      取れたら、<strong>1件目の名前だけ</strong>を <code>echo</code> で出してみましょう。
+      取れたら、<strong>1件目の名前だけ</strong>を <code>echo</code> で出してみましょう。<br>
+      確認が終わったら、<code>var_dump($rows);</code> と <code>echo $rows[0]['name'];</code> を削除してください。データを取り出して <code>$rows</code> に入れる処理は残します。
       <span class="ad-label">index.php（穴埋め）</span>
       <code class="ad-code hl"><span class="ad-v">$stmt</span> = <span class="ad-v">$pdo</span>-&gt;<span class="ad-f">query</span>(<span class="ad-s">'SELECT * FROM sortable ORDER BY id'</span>);
 <span class="ad-v">$rows</span> = <span class="ad-v">$stmt</span>-&gt;<span class="ad-f"><span class="blank">xxxxxx</span></span>();  <span class="ad-cm">/* 結果をまとめて配列で受け取るメソッドは？（この章） */</span>
@@ -829,11 +831,6 @@
 </main>
 
 <nav class="page-nav">
-  <a class="page-prev" href="advanced_4.html">
-    <span class="page-nav-label">前のページ</span>
-    <span class="page-nav-title">フロントエンド初級#4</span>
-    <span class="page-nav-sub">PHPを便利にするいろんな記号</span>
-  </a>
   <a class="page-next" href="advanced_6.html">
     <span class="page-nav-label">次のページ</span>
     <span class="page-nav-title">フロントエンド中級#6</span>

--- a/docs/training/cbc_internal/advanced_6.html
+++ b/docs/training/cbc_internal/advanced_6.html
@@ -233,7 +233,7 @@
 
     <div class="note">
       <span class="label">== ではなく ===</span><br>
-      <a href="advanced_4.html">フロントエンド初級#4</a> で出てきた比較です。<strong>イコールが2つと3つで意味が違います。</strong><br>
+      PHPの比較では、<strong>イコールが2つと3つで意味が違います。</strong><br>
       <code>==</code> は<strong>「だいたい同じ」</strong>。型が違っても、変換して同じなら通します。<code>'1' == 1</code> は <code>true</code> です。<br>
       <code>===</code> は<strong>「型まで同じ」</strong>。<code>'1' === 1</code> は <code>false</code> になります。<br>
       <strong>迷ったら <code>===</code> を使ってください。</strong>思わぬ値が通り抜けて、原因の分からない不具合になります。この教材では最後まで <code>===</code> と <code>!==</code> しか使いません。
@@ -325,8 +325,8 @@
     <div class="caution">
       <span class="label">送られてくる値は、全部「文字」</span><br>
       <a href="advanced_5.html#chapter2">#5</a> でDBから読んだときは <code>int(810)</code> のように型が付いていました。<strong>フォームから来る値は違います。</strong><br>
-      数字だけを入力しても、<code>$_POST['name']</code> は <code>string</code> です。<strong>HTMLには型が無いからです。</strong><br>
-      <a href="basic_7.html">マークアップ中級#7</a> でやった <code>'10' + 5</code> の問題は、ここで起きます。<strong>数として扱いたいときは <code>(int)</code> を付けて変換します。</strong>この書き方は <a href="advanced_7.html">#7</a> でも何度も出てきます。
+      数字だけを入力しても、<code>$_POST['name']</code> は <code>string</code> です。フォームの入力値をPHPが文字列として受け取るためです。<br>
+      ただし、PHPの <code>'10' + 5</code> は数値として加算され、<code>15</code> になります。文字列の連結には <code>.</code> を使います。<a href="basic_7.html">マークアップ中級#7</a> のJavaScriptとは演算子の動きが違います。座標のように<strong>整数として扱う値は <code>(int)</code> で変換します。</strong>この書き方は <a href="advanced_7.html">#7</a> でも使います。
     </div>
 
     <div class="caution">
@@ -495,6 +495,7 @@
     <div class="exercise">
       <span class="label">演習3</span><br>
       入力された名前を、<strong>実際にDBへ登録</strong>してください。<br>
+      演習2の <code>if ($name !== '') { ... }</code> を下のコードに置き換え、確認用の <code>echo</code> を残さないでください。外側の <code>if ($_SERVER['REQUEST_METHOD'] === 'POST') { ... }</code> は残します。<br>
       登録できたら画面を開き直して、<strong>一覧に増えているか</strong>確認します。<br>
       確認できたら、名前の欄に <code>'); DROP TABLE sortable; --</code> と入れてみてください。<strong>そういう名前の札が1つ増えるだけ</strong>なら、正しく書けています。<br>
       登録した札は <strong>すべて同じ場所（左上）に重なります。</strong>これは <code>left_x</code> と <code>top_y</code> に同じ値を入れているためです。ドラッグして動かせるようにするのは、次のページでやります。

--- a/docs/training/cbc_internal/advanced_7.html
+++ b/docs/training/cbc_internal/advanced_7.html
@@ -48,7 +48,7 @@
     <div class="exercise">
       <span class="label">課題</span><br>
       <code>03_advanced/htdocs/index.php</code> の仕上げです。<br>
-      章の途中に<strong>演習が4つ</strong>あります（この色の枠です）。出てきたその場で書いてください。<br>
+      章の途中に<strong>演習が5つ</strong>あります（この色の枠です）。出てきたその場で書いてください。<br>
       <strong>このページまで終われば、1つ目の画面が完成</strong>します。チェックリストの5項目が全部そろいます。
     </div>
 
@@ -99,7 +99,7 @@
     <div class="note">
       <span class="label">自分のコードは &lt;script&gt; の中に書く</span><br>
       この2本を読み込んだあと、<strong>同じ <code>&lt;head&gt;</code> の中に <code>&lt;script&gt; … &lt;/script&gt;</code> を1つ足して</strong>、そこに自分のコードを書きます。<br>
-      <a href="basic_6.html">マークアップ中級#6</a> では <code>js/main.js</code> という別ファイルを作りました。<strong>ここでは1枚のファイルにまとめて書きます。</strong>別ファイルに切り出すのは <a href="advanced_class1.html">#11</a> でやります。
+      <a href="basic_6.html">マークアップ中級#6</a> では <code>js/main.js</code> という別ファイルを作りました。<strong>ここでは1枚のファイルにまとめて書きます。</strong>別ファイルに切り出すのは <a href="advanced_class1.html">#8</a> でやります。
     </div>
 
     <h3>draggable を付ける</h3>
@@ -310,6 +310,10 @@
     </div>
 
     <h3>送る</h3>
+
+    <p>
+      下の <code>$.ajax()</code> から <code>.fail()</code> までを、<strong><code>stop: function () { ... }</code> の中で、<code>id</code>・<code>left</code>・<code>top</code> を取得した直後</strong>に書きます。<code>stop</code> の外では、これらの変数を参照できません。演習2では座標の確認まで行い、送信処理を追加するのは演習3です。
+    </p>
 
     <div class="vscode">
       <div class="vscode-titlebar">
@@ -552,6 +556,7 @@
     <div class="exercise">
       <span class="label">演習3</span><br>
       ドラッグした位置が<strong>DBに保存される</strong>ようにしてください。<br>
+      演習2で作った <code>stop</code> の中の <code>const top = ...;</code> の直後に、2章「送る」の <code>$.ajax()</code> から <code>.fail()</code> までを追加します。そのうえで、PHP側に下の更新処理を書いてください。<br>
       できたら、札を動かして<strong>ページを再読み込み</strong>します。<strong>動かした場所に残っていれば成功</strong>です。<br>
       うまくいかないときは、次の章の調べ方を先に読んでください。
       <span class="ad-label">index.php（穴埋め）</span>

--- a/docs/training/cbc_internal/advanced_class1.html
+++ b/docs/training/cbc_internal/advanced_class1.html
@@ -502,7 +502,7 @@ function/update.php     → 更新
 <span class="ad-k"><span class="blank">xxxxxx</span></span> <span class="ad-c">__DIR__</span> . <span class="ad-s">'/config/config.php'</span>;  <span class="ad-cm">/* 無いと止まる・1回だけ読む書き方は？（この章） */</span>
 
 <span class="ad-v">$rows</span> = <span class="ad-v">$pdo</span>-&gt;<span class="ad-f">query</span>(
-    <span class="ad-s">'SELECT s.*, g.department
+    <span class="ad-s">'SELECT s.*, g.department AS department_name
      FROM sortable AS s
      LEFT JOIN departments AS g ON s.department_id = g.id
      ORDER BY s.id'</span>
@@ -549,7 +549,7 @@ function/update.php     → 更新
 <span class="ad-k">require_once</span> <span class="ad-c">__DIR__</span> . <span class="ad-s">'/config/config.php'</span>;
 
 <span class="ad-v">$rows</span> = <span class="ad-v">$pdo</span>-&gt;<span class="ad-f">query</span>(
-    <span class="ad-s">'SELECT s.*, g.department
+    <span class="ad-s">'SELECT s.*, g.department AS department_name
      FROM sortable AS s
      LEFT JOIN departments AS g ON s.department_id = g.id
      ORDER BY s.id'</span>

--- a/docs/training/cbc_internal/advanced_class2.html
+++ b/docs/training/cbc_internal/advanced_class2.html
@@ -289,14 +289,14 @@
     <div class="ad-compare">
       <div class="ad-compare-item is-ng">
         <span class="ad-compare-label">#8 のとき</span>
-        <code class="ad-code">require_once '../config/config.php';
+        <code class="ad-code">require_once __DIR__ . '/config/config.php';
 
 $stmt = $pdo->query($sql);
 $rows = $stmt->fetchAll();</code>
       </div>
       <div class="ad-compare-item is-ok">
         <span class="ad-compare-label">クラスにすると</span>
-        <code class="ad-code">require_once '../Controller/Connect.php';
+        <code class="ad-code">require_once __DIR__ . '/Controller/Connect.php';
 
 $select = new SelectData();
 $rows = $select->select($sql);</code>
@@ -626,7 +626,7 @@ if (isset($_POST['id'])) {
 }</code>
       </div>
       <div class="ad-compare-item is-ok">
-        <span class="ad-compare-label">#12（sortable3）</span>
+        <span class="ad-compare-label">#9（sortable3）</span>
         <code class="ad-code">require_once __DIR__ . '/../Controller/Connect.php';
 require_once __DIR__ . '/../Controller/AppController.php';
 
@@ -687,7 +687,7 @@ if (isset($_POST['id'])) {
 <span class="ad-v">$select</span> = <span class="ad-k">new</span> <span class="ad-c">SelectData</span>();
 
 <span class="ad-v">$rows</span> = <span class="ad-v">$select</span>-&gt;<span class="ad-f">select</span>(
-    <span class="ad-s">'SELECT s.*, g.department
+    <span class="ad-s">'SELECT s.*, g.department AS department_name
      FROM sortable AS s
      LEFT JOIN departments AS g ON s.department_id = g.id
      ORDER BY s.id'</span>
@@ -709,7 +709,7 @@ if (isset($_POST['id'])) {
     <div class="ac2-three">
       <div class="ac2-three-item">
         <span class="ac2-three-name">index.php</span>
-        <span class="ac2-three-sub">#1〜#10</span>
+        <span class="ac2-three-sub">#5〜#7</span>
         <p>1枚に全部。<strong>動くものを作った</strong></p>
       </div>
       <div class="ac2-three-item">
@@ -719,7 +719,7 @@ if (isset($_POST['id'])) {
       </div>
       <div class="ac2-three-item">
         <span class="ac2-three-name">sortable3/</span>
-        <span class="ac2-three-sub">#12</span>
+        <span class="ac2-three-sub">#9</span>
         <p>クラスにまとめた。<strong>持ち運べるようになった</strong></p>
       </div>
     </div>

--- a/docs/training/files/03_advanced_kadai/htdocs/sortable2/index.php
+++ b/docs/training/files/03_advanced_kadai/htdocs/sortable2/index.php
@@ -1,2 +1,2 @@
 <?php
-echo "「#11 PHPでClassクラスを理解するための準備」で、このファイルを上書きしてください。 sortable2/index.php";
+echo "「#8 ファイルを機能別に分ける」で、このファイルを上書きしてください。 sortable2/index.php";

--- a/docs/training/files/03_advanced_kadai/htdocs/sortable3/index.php
+++ b/docs/training/files/03_advanced_kadai/htdocs/sortable3/index.php
@@ -1,2 +1,2 @@
 <?php
-echo "「#12 PHPアプリケーションをクラス化してみよう」で、このファイルを上書きしてください。 sortable3/index.php";
+echo "「#9 クラスにまとめる」で、このファイルを上書きしてください。 sortable3/index.php";

--- a/docs/training/files/03_advanced_kadai_answer/htdocs/css/style.css
+++ b/docs/training/files/03_advanced_kadai_answer/htdocs/css/style.css
@@ -28,10 +28,11 @@ header h1 {
 }
 
 main {
-  /* 座標は最大 824。札の幅を足しても収まるように広げてある */
+  /* 保存座標を保ち、狭い画面では配置領域を横スクロールする */
   max-width: 1060px;
   margin: 0 auto;
   padding: 20px 24px 32px;
+  overflow-x: auto;
 }
 
 /* ------------------------------------------------------------
@@ -85,6 +86,7 @@ main {
    ------------------------------------------------------------ */
 #drag-area {
   position: relative;
+  min-width: 1012px;
   height: 560px;
   border-radius: 12px;
   background: #ffffff;

--- a/docs/training/files/03_advanced_kadai_answer/htdocs/sortable2/css/style.css
+++ b/docs/training/files/03_advanced_kadai_answer/htdocs/sortable2/css/style.css
@@ -28,10 +28,11 @@ header h1 {
 }
 
 main {
-  /* 座標は最大 824。札の幅を足しても収まるように広げてある */
+  /* 保存座標を保ち、狭い画面では配置領域を横スクロールする */
   max-width: 1060px;
   margin: 0 auto;
   padding: 20px 24px 32px;
+  overflow-x: auto;
 }
 
 /* ------------------------------------------------------------
@@ -85,6 +86,7 @@ main {
    ------------------------------------------------------------ */
 #drag-area {
   position: relative;
+  min-width: 1012px;
   height: 560px;
   border-radius: 12px;
   background: #ffffff;

--- a/docs/training/files/03_advanced_kadai_answer/htdocs/sortable3/css/style.css
+++ b/docs/training/files/03_advanced_kadai_answer/htdocs/sortable3/css/style.css
@@ -28,10 +28,11 @@ header h1 {
 }
 
 main {
-  /* 座標は最大 824。札の幅を足しても収まるように広げてある */
+  /* 保存座標を保ち、狭い画面では配置領域を横スクロールする */
   max-width: 1060px;
   margin: 0 auto;
   padding: 20px 24px 32px;
+  overflow-x: auto;
 }
 
 /* ------------------------------------------------------------
@@ -85,6 +86,7 @@ main {
    ------------------------------------------------------------ */
 #drag-area {
   position: relative;
+  min-width: 1012px;
   height: 560px;
   border-radius: 12px;
   background: #ffffff;


### PR DESCRIPTION
## 概要

フロントエンド編の本文と配布課題・解答を照合し、記述の誤りと不整合を修正しました。
本文どおりに進めても完成しない箇所、実際と違う説明、番号の付け替え漏れが対象です。

## 変更内容

### advanced_5.html

- 冒頭の演習数を3つから4つに訂正
- PDOのエラー処理の説明を「PHP 8以降は例外が既定。この教材では明示する」に統一
- 演習2に、確認用の `echo '接続成功';` を削除する指示を追加
- 演習3に、`var_dump($rows);` と `echo $rows[0]['name'];` を削除し、取得処理は残す指示を追加
- `'10' + 5` の説明を、PHPとJavaScriptで動きが違う旨に訂正

### advanced_6.html

- PHPの `'10' + 5` は15になること、連結は `.` を使うことに訂正
- 演習3に、確認用の `echo` を残さない旨と、残す `if` の範囲を追記

### advanced_7.html

- 冒頭の演習数を4つから5つに訂正
- ファイル分割の参照を #11 から #8 に訂正
- `$.ajax()` から `.fail()` までを `stop` の中、座標取得の直後に書くことを明示
- 演習3に、Ajaxの送信処理とPHPの更新処理の両方を追加する指示を追記

### advanced_class1.html

- SQLに `AS department_name` を戻し、#7 と同じ取得キーに統一

### advanced_class2.html

- `Connect.php` と `config.php` の読み込みを `__DIR__` 基準に統一
- SQLに `AS department_name` を追加
- 旧番号 #12 を #9 に、#1〜#10 を #5〜#7 に訂正

### 配布課題の雛形

- sortable2/index.php・sortable3/index.php の案内文を現在の番号に変更

### 解答のCSS（3画面ぶん）

- `main` に `overflow-x: auto`、`#drag-area` に `min-width: 1012px` を追加
- 保存座標をそのままに、狭い画面では配置領域を横スクロールして確認できるようにしました

## 確認

PHP 8.5.9・MySQL 8.4.11 で、本文どおりに組み立てたコードと解答の両方を通しで実行しました。
一覧表示、登録、ドラッグでの座標保存、再読み込み後の位置保持まで確認しています。
幅375px・928px・1280px での表示も確認しました。